### PR TITLE
Add shared brand header across reports

### DIFF
--- a/Design_Thinking_in_SDLC.html
+++ b/Design_Thinking_in_SDLC.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles/brand-header.css">
   <style>
     body {
       font-family: 'Inter', sans-serif;
@@ -133,10 +134,23 @@
   </style>
 </head>
 <body class="smooth-scroll">
-  <header class="w-full bg-white/90 backdrop-blur sticky top-0 z-50 border-b border-slate-200">
-    <div class="max-w-5xl mx-auto flex items-center justify-between px-4 sm:px-6 py-4">
-      <span class="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">Design Thinking Playbook</span>
-      <a href="index.html" class="home-button" aria-label="Return to the home page">← Home</a>
+  <header class="brand-header">
+    <div class="brand-header__bar">
+      <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+        <span class="brand-header__glyph" aria-hidden="true">SE</span>
+        <span class="brand-header__lockup">
+          <span>Software Advisory</span>
+          <span>Brightscale Partners</span>
+        </span>
+      </a>
+      <nav class="brand-header__nav" aria-label="Primary">
+        <a class="brand-header__link" href="index.html#services">Services</a>
+        <a class="brand-header__link" href="index.html#industries">Industries</a>
+        <a class="brand-header__link" href="index.html#explore">Insights</a>
+        <a class="brand-header__link" href="index.html#about">About</a>
+        <a class="brand-header__link" href="index.html#contact">Contact</a>
+      </nav>
+      <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
     </div>
   </header>
   <div class="pt-6 sm:pt-8 lg:pt-12">

--- a/FinOps_Detailed.html
+++ b/FinOps_Detailed.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/brand-header.css">
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -123,6 +124,26 @@
     </style>
 </head>
 <body class="smooth-scroll">
+
+    <header class="brand-header">
+        <div class="brand-header__bar">
+            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+                <span class="brand-header__glyph" aria-hidden="true">SE</span>
+                <span class="brand-header__lockup">
+                    <span>Software Advisory</span>
+                    <span>Brightscale Partners</span>
+                </span>
+            </a>
+            <nav class="brand-header__nav" aria-label="Primary">
+                <a class="brand-header__link" href="index.html#services">Services</a>
+                <a class="brand-header__link" href="index.html#industries">Industries</a>
+                <a class="brand-header__link" href="index.html#explore">Insights</a>
+                <a class="brand-header__link" href="index.html#about">About</a>
+                <a class="brand-header__link" href="index.html#contact">Contact</a>
+            </nav>
+            <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+        </div>
+    </header>
 
     <div class="min-h-screen flex flex-col lg:flex-row">
         <!-- Mobile Header (hidden on large screens) -->

--- a/FinOps_Summary.html
+++ b/FinOps_Summary.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles/brand-header.css">
   <!-- Palette: Slate + Amber -->
   <style>
     body { font-family: 'Inter', sans-serif; background-color:#f8fafc; color:#1e293b; }
@@ -28,8 +29,28 @@
 </head>
 <body class="smooth-scroll">
 
-<header class="bg-white/80 backdrop-blur-lg sticky top-0 z-50 shadow-sm">
-  <nav class="container mx-auto px-6 py-4 flex flex-wrap items-center justify-between gap-4">
+<header class="brand-header">
+  <div class="brand-header__bar">
+    <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+      <span class="brand-header__glyph" aria-hidden="true">SE</span>
+      <span class="brand-header__lockup">
+        <span>Software Advisory</span>
+        <span>Brightscale Partners</span>
+      </span>
+    </a>
+    <nav class="brand-header__nav" aria-label="Primary">
+      <a class="brand-header__link" href="index.html#services">Services</a>
+      <a class="brand-header__link" href="index.html#industries">Industries</a>
+      <a class="brand-header__link" href="index.html#explore">Insights</a>
+      <a class="brand-header__link" href="index.html#about">About</a>
+      <a class="brand-header__link" href="index.html#contact">Contact</a>
+    </nav>
+    <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+  </div>
+</header>
+
+<nav class="bg-white/80 backdrop-blur-lg sticky top-0 z-40 shadow-sm">
+  <div class="container mx-auto px-6 py-4 flex flex-wrap items-center justify-between gap-4">
     <div class="flex items-center justify-between w-full md:w-auto gap-4">
       <h1 class="text-2xl font-extrabold text-slate-800">FinOps, Explained</h1>
       <a href="index.html" class="home-button md:hidden text-sm" aria-label="Return to the home page">Home</a>
@@ -54,8 +75,8 @@
         <option value="#tooling">Tooling</option>
       </select>
     </div>
-  </nav>
-</header>
+  </div>
+</nav>
 
 <main class="container mx-auto px-6 py-8 md:py-12">
 

--- a/Platform_Engineering.html
+++ b/Platform_Engineering.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/brand-header.css">
     <!-- Chosen Palette: "Calm Harmony" - A mix of warm neutrals (bg-stone-50, bg-stone-100), a gentle primary color (sky-600), and subtle accents (amber-500). -->
     <!-- Application Structure Plan: The SPA is designed with a thematic, single-column scrolling structure, guided by a sticky top navigation. This approach allows users to either follow a logical narrative from top to bottom (from 'Why it Matters' to 'Future State') or jump directly to a section of interest. The key interactions involve hovering over charts for detailed data and clicking navigation links for smooth scrolling. This structure was chosen to simplify a dense report, making it digestible and easy to navigate for users who might be new to the topic or those looking for specific data points, thus maximizing usability and comprehension. -->
     <!-- Visualization & Content Choices:
@@ -86,9 +87,30 @@
 </head>
 <body class="smooth-scroll">
 
-    <!-- Header & Navigation -->
-    <header class="bg-white/80 backdrop-blur-lg sticky top-0 z-50 shadow-sm">
-        <nav class="container mx-auto px-6 py-4 flex justify-between items-center gap-4">
+    <!-- Global Brand Header -->
+    <header class="brand-header">
+        <div class="brand-header__bar">
+            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+                <span class="brand-header__glyph" aria-hidden="true">SE</span>
+                <span class="brand-header__lockup">
+                    <span>Software Advisory</span>
+                    <span>Brightscale Partners</span>
+                </span>
+            </a>
+            <nav class="brand-header__nav" aria-label="Primary">
+                <a class="brand-header__link" href="index.html#services">Services</a>
+                <a class="brand-header__link" href="index.html#industries">Industries</a>
+                <a class="brand-header__link" href="index.html#explore">Insights</a>
+                <a class="brand-header__link" href="index.html#about">About</a>
+                <a class="brand-header__link" href="index.html#contact">Contact</a>
+            </nav>
+            <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+        </div>
+    </header>
+
+    <!-- Report Navigation -->
+    <nav class="bg-white/80 backdrop-blur-lg sticky top-0 z-40 shadow-sm">
+        <div class="container mx-auto px-6 py-4 flex justify-between items-center gap-4">
             <div class="flex items-center gap-4">
                 <h1 class="text-2xl font-bold text-slate-800">Platform Engineering</h1>
             </div>
@@ -106,7 +128,7 @@
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path></svg>
                 </button>
             </div>
-        </nav>
+        </div>
         <!-- Mobile Menu -->
         <div id="mobile-menu" class="hidden md:hidden px-6 pb-4">
             <a href="#introduction" class="block py-2 nav-link font-medium text-slate-600">Introduction</a>
@@ -116,7 +138,7 @@
             <a href="#future" class="block py-2 nav-link font-medium text-slate-600">Future</a>
             <a href="index.html" class="home-button mt-3 w-full justify-center" aria-label="Return to the home page">Home</a>
         </div>
-    </header>
+    </nav>
 
     <main class="container mx-auto px-6 py-12">
 

--- a/Software_Code_Pipeline.html
+++ b/Software_Code_Pipeline.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/brand-header.css">
     <!-- Chosen Palette: Cool Blues & Grays -->
     <!-- Application Structure Plan: The application is designed as an interactive, linear flowchart representing the code pipeline. This structure was chosen because it visually mirrors the actual process, making the flow of code from development to production intuitive and easy to follow. Users can click on each distinct stage of the pipeline (e.g., 'Collaborate', 'CI', 'CD') to reveal a detailed explanation below. This approach provides a high-level overview while allowing for self-paced, deep dives into specific topics, which is more engaging and effective for learning than a static document or a tabbed interface. -->
     <!-- Visualization & Content Choices: 
@@ -88,6 +89,25 @@
     </style>
 </head>
 <body class="antialiased">
+    <header class="brand-header">
+        <div class="brand-header__bar">
+            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+                <span class="brand-header__glyph" aria-hidden="true">SE</span>
+                <span class="brand-header__lockup">
+                    <span>Software Advisory</span>
+                    <span>Brightscale Partners</span>
+                </span>
+            </a>
+            <nav class="brand-header__nav" aria-label="Primary">
+                <a class="brand-header__link" href="index.html#services">Services</a>
+                <a class="brand-header__link" href="index.html#industries">Industries</a>
+                <a class="brand-header__link" href="index.html#explore">Insights</a>
+                <a class="brand-header__link" href="index.html#about">About</a>
+                <a class="brand-header__link" href="index.html#contact">Contact</a>
+            </nav>
+            <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+        </div>
+    </header>
     <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div class="flex justify-end mb-8">
             <a href="index.html" class="home-button" aria-label="Return to the home page">← Home</a>

--- a/Software_Security_Detailed.html
+++ b/Software_Security_Detailed.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/brand-header.css">
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -123,6 +124,26 @@
     </style>
 </head>
 <body class="smooth-scroll">
+
+    <header class="brand-header">
+        <div class="brand-header__bar">
+            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+                <span class="brand-header__glyph" aria-hidden="true">SE</span>
+                <span class="brand-header__lockup">
+                    <span>Software Advisory</span>
+                    <span>Brightscale Partners</span>
+                </span>
+            </a>
+            <nav class="brand-header__nav" aria-label="Primary">
+                <a class="brand-header__link" href="index.html#services">Services</a>
+                <a class="brand-header__link" href="index.html#industries">Industries</a>
+                <a class="brand-header__link" href="index.html#explore">Insights</a>
+                <a class="brand-header__link" href="index.html#about">About</a>
+                <a class="brand-header__link" href="index.html#contact">Contact</a>
+            </nav>
+            <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+        </div>
+    </header>
 
     <div class="min-h-screen flex flex-col lg:flex-row">
         <!-- Mobile Header (hidden on large screens) -->

--- a/Software_Security_Summary.html
+++ b/Software_Security_Summary.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles/brand-header.css">
   <style>
     body{font-family:'Inter',sans-serif;background-color:#f8fafc;color:#1e293b}
     .smooth-scroll{scroll-behavior:smooth}
@@ -20,6 +21,25 @@
   </style>
 </head>
 <body class="smooth-scroll">
+  <header class="brand-header">
+    <div class="brand-header__bar">
+      <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+        <span class="brand-header__glyph" aria-hidden="true">SE</span>
+        <span class="brand-header__lockup">
+          <span>Software Advisory</span>
+          <span>Brightscale Partners</span>
+        </span>
+      </a>
+      <nav class="brand-header__nav" aria-label="Primary">
+        <a class="brand-header__link" href="index.html#services">Services</a>
+        <a class="brand-header__link" href="index.html#industries">Industries</a>
+        <a class="brand-header__link" href="index.html#explore">Insights</a>
+        <a class="brand-header__link" href="index.html#about">About</a>
+        <a class="brand-header__link" href="index.html#contact">Contact</a>
+      </nav>
+      <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+    </div>
+  </header>
   <div class="min-h-screen lg:flex">
     <!-- Sidebar -->
     <aside class="hidden lg:block lg:w-72 bg-white p-6 shadow-lg sticky top-0 h-screen overflow-y-auto">

--- a/Software_Suppy_Chain.html
+++ b/Software_Suppy_Chain.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/brand-header.css">
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -102,6 +103,25 @@
     </style>
 </head>
 <body class="smooth-scroll p-4">
+    <header class="brand-header">
+        <div class="brand-header__bar">
+            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+                <span class="brand-header__glyph" aria-hidden="true">SE</span>
+                <span class="brand-header__lockup">
+                    <span>Software Advisory</span>
+                    <span>Brightscale Partners</span>
+                </span>
+            </a>
+            <nav class="brand-header__nav" aria-label="Primary">
+                <a class="brand-header__link" href="index.html#services">Services</a>
+                <a class="brand-header__link" href="index.html#industries">Industries</a>
+                <a class="brand-header__link" href="index.html#explore">Insights</a>
+                <a class="brand-header__link" href="index.html#about">About</a>
+                <a class="brand-header__link" href="index.html#contact">Contact</a>
+            </nav>
+            <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+        </div>
+    </header>
     <!-- Navigation Bar -->
     <nav class="bg-gray-800 p-4 shadow-md sticky top-0 z-50 rounded-lg">
         <div class="container mx-auto flex flex-col md:flex-row items-center justify-between">

--- a/Top_Challenges_in_Software_Engineering.html
+++ b/Top_Challenges_in_Software_Engineering.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/brand-header.css">
     <!-- Chosen Palette: Warm Neutral Harmony -->
     <!-- Application Structure Plan: A dashboard-style SPA featuring a central interactive radar chart for a high-level overview, key statistic cards for quick insights, and three thematic sections (Technology, Process, People) to group related challenges. Clicking any challenge (on the chart or in a section) reveals a detailed, dynamically-populated content pane. This structure was chosen to transform the linear report into an exploratory experience, highlighting the interconnectedness of the challenges and allowing users to move from a broad summary to deep-dive analysis intuitively, which enhances usability and comprehension over a simple text layout. -->
     <!-- Visualization & Content Choices: 
@@ -89,8 +90,28 @@
 </head>
 <body class="antialiased">
 
-    <header class="bg-white/80 backdrop-blur-lg sticky top-0 z-30 shadow-sm">
-        <nav class="container mx-auto px-6 py-4">
+    <header class="brand-header">
+        <div class="brand-header__bar">
+            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+                <span class="brand-header__glyph" aria-hidden="true">SE</span>
+                <span class="brand-header__lockup">
+                    <span>Software Advisory</span>
+                    <span>Brightscale Partners</span>
+                </span>
+            </a>
+            <nav class="brand-header__nav" aria-label="Primary">
+                <a class="brand-header__link" href="index.html#services">Services</a>
+                <a class="brand-header__link" href="index.html#industries">Industries</a>
+                <a class="brand-header__link" href="index.html#explore">Insights</a>
+                <a class="brand-header__link" href="index.html#about">About</a>
+                <a class="brand-header__link" href="index.html#contact">Contact</a>
+            </nav>
+            <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+        </div>
+    </header>
+
+    <nav class="bg-white/80 backdrop-blur-lg sticky top-0 z-30 shadow-sm">
+        <div class="container mx-auto px-6 py-4">
             <div class="flex items-center justify-between gap-4">
                 <div class="flex items-center gap-4">
                     <h1 class="text-xl md:text-2xl font-bold text-emerald-700">Software Engineering Challenges</h1>
@@ -104,8 +125,8 @@
                     <a href="#forward" class="nav-link border-b-2 border-transparent hover:text-emerald-600 pb-1">Path Forward</a>
                 </div>
             </div>
-        </nav>
-    </header>
+        </div>
+    </nav>
 
     <main class="container mx-auto px-6 py-8 md:py-12">
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles/brand-header.css">
   <style>
     body {
       font-family: 'Inter', sans-serif;
@@ -56,38 +57,55 @@
 <body id="top" class="min-h-screen flex flex-col">
   <main class="flex-1">
     <div class="max-w-6xl mx-auto px-6 py-12 space-y-16">
-      <header class="relative overflow-hidden rounded-3xl bg-gradient-to-br from-slate-950 via-blue-900 to-cyan-700 text-white shadow-xl">
-        <div class="absolute -top-32 -right-24 h-72 w-72 rounded-full bg-cyan-400/40 blur-3xl"></div>
-        <div class="absolute -bottom-32 -left-24 h-72 w-72 rounded-full bg-indigo-500/40 blur-3xl"></div>
-        <div class="relative px-8 py-16 sm:px-12 lg:px-16">
-          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-sky-200">Insight Library</p>
-          <h1 class="mt-4 text-3xl sm:text-4xl md:text-5xl font-bold leading-tight max-w-3xl">
+      <header class="brand-header brand-header--on-dark relative overflow-hidden rounded-3xl bg-gradient-to-br from-slate-950 via-blue-900 to-cyan-700 text-white shadow-xl">
+        <div class="absolute -top-32 -right-24 h-72 w-72 rounded-full bg-cyan-400/40 blur-3xl" aria-hidden="true"></div>
+        <div class="absolute -bottom-32 -left-24 h-72 w-72 rounded-full bg-indigo-500/40 blur-3xl" aria-hidden="true"></div>
+        <div class="brand-header__bar relative z-10 w-full">
+          <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+            <span class="brand-header__glyph" aria-hidden="true">SE</span>
+            <span class="brand-header__lockup">
+              <span>Software Advisory</span>
+              <span>Brightscale Partners</span>
+            </span>
+          </a>
+          <nav class="brand-header__nav" aria-label="Primary">
+            <a class="brand-header__link" href="index.html#services">Services</a>
+            <a class="brand-header__link" href="index.html#industries">Industries</a>
+            <a class="brand-header__link" href="index.html#explore">Insights</a>
+            <a class="brand-header__link" href="index.html#about">About</a>
+            <a class="brand-header__link" href="index.html#contact">Contact</a>
+          </nav>
+          <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+        </div>
+        <div class="brand-hero relative z-10 text-white">
+          <p class="brand-hero__eyebrow text-sky-200">Insight Library</p>
+          <h1 class="brand-hero__title mt-4 text-3xl sm:text-4xl md:text-5xl max-w-3xl">
             Software Engineering Knowledge Hub
           </h1>
-          <p class="mt-6 max-w-2xl text-lg text-slate-100/85">
+          <p class="brand-hero__lede text-slate-100/85">
             Curated research, executive briefings, and interactive explorations to help teams build resilient, scalable, and
             human-centred software.
           </p>
-          <div class="mt-8 flex flex-wrap gap-4">
-            <a href="#explore" class="inline-flex items-center justify-center rounded-full bg-white/90 px-5 py-2 text-sm font-semibold text-slate-900 shadow-lg shadow-cyan-900/20 transition hover:-translate-y-0.5 hover:bg-white">
+          <div class="brand-hero__actions">
+            <a href="#explore" class="brand-hero__action-primary">
               Explore Reports
             </a>
-            <a href="#unit-testing" class="inline-flex items-center justify-center rounded-full border border-white/70 px-5 py-2 text-sm font-semibold text-white backdrop-blur transition hover:-translate-y-0.5 hover:bg-white/10">
+            <a href="#unit-testing" class="brand-hero__action-secondary">
               Discover Unit Testing Insights
             </a>
           </div>
-          <dl class="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-3 text-left">
-            <div class="rounded-2xl bg-white/10 px-6 py-5 backdrop-blur">
-              <dt class="text-xs uppercase tracking-wide text-slate-200">Reports & Guides</dt>
-              <dd class="mt-2 text-3xl font-semibold">10+</dd>
+          <dl class="brand-hero__stats">
+            <div class="brand-hero__stat-card">
+              <dt class="brand-hero__stat-label">Reports & Guides</dt>
+              <dd class="brand-hero__stat-value">10+</dd>
             </div>
-            <div class="rounded-2xl bg-white/10 px-6 py-5 backdrop-blur">
-              <dt class="text-xs uppercase tracking-wide text-slate-200">Focus Areas</dt>
-              <dd class="mt-2 text-3xl font-semibold">7</dd>
+            <div class="brand-hero__stat-card">
+              <dt class="brand-hero__stat-label">Focus Areas</dt>
+              <dd class="brand-hero__stat-value">7</dd>
             </div>
-            <div class="rounded-2xl bg-white/10 px-6 py-5 backdrop-blur">
-              <dt class="text-xs uppercase tracking-wide text-slate-200">Interactive Deep Dives</dt>
-              <dd class="mt-2 text-3xl font-semibold">4</dd>
+            <div class="brand-hero__stat-card">
+              <dt class="brand-hero__stat-label">Interactive Deep Dives</dt>
+              <dd class="brand-hero__stat-value">4</dd>
             </div>
           </dl>
         </div>

--- a/platform-engineering-executive-report.html
+++ b/platform-engineering-executive-report.html
@@ -10,6 +10,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="styles/brand-header.css">
 
 <style>
   :root {
@@ -263,6 +264,25 @@
 </style>
 </head>
 <body class="smooth-scroll" data-theme="dark">
+  <header class="brand-header brand-header--on-dark">
+    <div class="brand-header__bar">
+      <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+        <span class="brand-header__glyph" aria-hidden="true">SE</span>
+        <span class="brand-header__lockup">
+          <span>Software Advisory</span>
+          <span>Brightscale Partners</span>
+        </span>
+      </a>
+      <nav class="brand-header__nav" aria-label="Primary">
+        <a class="brand-header__link" href="index.html#services">Services</a>
+        <a class="brand-header__link" href="index.html#industries">Industries</a>
+        <a class="brand-header__link" href="index.html#explore">Insights</a>
+        <a class="brand-header__link" href="index.html#about">About</a>
+        <a class="brand-header__link" href="index.html#contact">Contact</a>
+      </nav>
+      <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+    </div>
+  </header>
   <div class="app">
     <nav>
       <div class="brand">

--- a/styles/brand-header.css
+++ b/styles/brand-header.css
@@ -1,0 +1,262 @@
+.brand-header {
+  background-color: #ffffff;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  position: relative;
+  z-index: 40;
+}
+
+.brand-header--on-dark {
+  background-color: transparent;
+  border-bottom-color: rgba(255, 255, 255, 0.18);
+}
+
+.brand-header__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.brand-header__identity {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: inherit;
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  font-size: 1.15rem;
+}
+
+.brand-header__glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #0f172a, #2563eb);
+  color: #ffffff;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.brand-header__lockup {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.brand-header__lockup span:first-child {
+  font-size: 0.85rem;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.brand-header__lockup span:last-child {
+  font-size: 1.15rem;
+}
+
+.brand-header__nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-weight: 500;
+}
+
+.brand-header__link {
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+  padding-bottom: 0.25rem;
+}
+
+.brand-header__link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: currentColor;
+  opacity: 0;
+  transform: scaleX(0.5);
+  transform-origin: center;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.brand-header__link:focus-visible::after,
+.brand-header__link:hover::after {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+.brand-header__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  padding: 0.65rem 1.5rem;
+  font-weight: 600;
+  text-decoration: none;
+  background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+  color: #0f172a;
+  box-shadow: 0 12px 24px -12px rgba(14, 165, 233, 0.55);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.brand-header__cta:hover,
+.brand-header__cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px -14px rgba(8, 145, 178, 0.6);
+  filter: brightness(1.05);
+}
+
+.brand-header__cta:focus-visible {
+  outline: 3px solid rgba(56, 189, 248, 0.45);
+  outline-offset: 2px;
+}
+
+.brand-header--on-dark .brand-header__bar {
+  color: #f8fafc;
+}
+
+.brand-header--on-dark .brand-header__cta {
+  color: #0f172a;
+}
+
+.brand-header--on-dark .brand-header__glyph {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(14, 116, 144, 0.95));
+}
+
+@media (max-width: 768px) {
+  .brand-header__bar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .brand-header__nav {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .brand-header__cta {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+.brand-hero {
+  position: relative;
+  padding: 3.5rem 2.5rem 4rem;
+}
+
+@media (min-width: 768px) {
+  .brand-hero {
+    padding: 4.5rem 4rem 5rem;
+  }
+}
+
+.brand-hero__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  font-weight: 600;
+  opacity: 0.75;
+}
+
+.brand-hero__title {
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.brand-hero__lede {
+  margin-top: 1.5rem;
+  font-size: 1.05rem;
+  max-width: 38rem;
+}
+
+.brand-hero__actions {
+  margin-top: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.brand-hero__stats {
+  margin-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .brand-hero__stats {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.brand-hero__stat-card {
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(6px);
+}
+
+.brand-hero__stat-label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  opacity: 0.8;
+}
+
+.brand-hero__stat-value {
+  margin-top: 0.75rem;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.brand-hero__action-primary,
+.brand-hero__action-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.brand-hero__action-primary {
+  background: rgba(255, 255, 255, 0.9);
+  color: #0f172a;
+  box-shadow: 0 12px 20px -12px rgba(15, 23, 42, 0.65);
+}
+
+.brand-hero__action-secondary {
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  color: #f8fafc;
+  backdrop-filter: blur(4px);
+}
+
+.brand-hero__action-primary:hover,
+.brand-hero__action-primary:focus-visible,
+.brand-hero__action-secondary:hover,
+.brand-hero__action-secondary:focus-visible {
+  transform: translateY(-2px);
+}
+
+.brand-hero__action-secondary:hover,
+.brand-hero__action-secondary:focus-visible {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.brand-hero__action-primary:focus-visible,
+.brand-hero__action-secondary:focus-visible {
+  outline: 3px solid rgba(248, 250, 252, 0.45);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- introduce a reusable brand navigation header component styled via a new styles/brand-header.css file
- update the home page hero and all report pages to include the new brand bar with consistent CTA links
- link each page to the shared stylesheet for the navigation system

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cc15fe85988325b995130c84af274b