### PR TITLE
Add consulting narrative sections to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
           <nav class="brand-header__nav" aria-label="Primary">
             <a class="brand-header__link" href="index.html#services">Services</a>
             <a class="brand-header__link" href="index.html#industries">Industries</a>
-            <a class="brand-header__link" href="index.html#explore">Insights</a>
+            <a class="brand-header__link" href="index.html#insights">Insights</a>
             <a class="brand-header__link" href="index.html#about">About</a>
             <a class="brand-header__link" href="index.html#contact">Contact</a>
           </nav>
@@ -87,7 +87,7 @@
             human-centred software.
           </p>
           <div class="brand-hero__actions">
-            <a href="#explore" class="brand-hero__action-primary">
+            <a href="#insights" class="brand-hero__action-primary">
               Explore Reports
             </a>
             <a href="#unit-testing" class="brand-hero__action-secondary">
@@ -111,10 +111,178 @@
         </div>
       </header>
 
-      <section id="explore" class="space-y-8">
+      <section id="firm-overview" class="grid gap-10 rounded-3xl bg-white/80 p-10 shadow-xl ring-1 ring-slate-200/60 backdrop-blur">
+        <div class="grid gap-10 lg:grid-cols-2 lg:items-center">
+          <div class="space-y-6">
+            <span class="inline-flex items-center gap-2 rounded-full bg-sky-100 px-4 py-1 text-sm font-medium text-sky-700">Trusted Advisors for Modern Engineering Leaders</span>
+            <h2 class="text-3xl font-semibold text-slate-900">Brightscale Partners at a Glance</h2>
+            <p class="text-lg text-slate-600">
+              We help software-driven organizations translate strategy into measurable delivery outcomes. Our senior practitioners bring decades of transformation experience across product engineering, platform modernization, and secure operations to every engagement.
+            </p>
+            <div class="grid gap-4 sm:grid-cols-2">
+              <div class="flex items-start gap-3 rounded-2xl bg-slate-50 p-4 shadow-sm ring-1 ring-slate-100">
+                <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-sky-600/10 text-xl">⚙️</div>
+                <div>
+                  <p class="font-semibold text-slate-800">Outcome Engineering</p>
+                  <p class="text-sm text-slate-600">Structured, metrics-led programs aligned to executive priorities.</p>
+                </div>
+              </div>
+              <div class="flex items-start gap-3 rounded-2xl bg-slate-50 p-4 shadow-sm ring-1 ring-slate-100">
+                <div class="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-600/10 text-xl">🤝</div>
+                <div>
+                  <p class="font-semibold text-slate-800">Embedded Partnership</p>
+                  <p class="text-sm text-slate-600">Advisors work beside your teams to accelerate adoption and change.</p>
+                </div>
+              </div>
+            </div>
+            <div class="flex flex-wrap gap-3">
+              <a href="#services" class="inline-flex items-center justify-center rounded-full bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-900/30 transition hover:bg-slate-700">Explore Consulting Pillars</a>
+              <a href="mailto:hello@brightscale.partners" class="inline-flex items-center justify-center rounded-full border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-900 transition hover:border-slate-900 hover:text-slate-900">Schedule a Strategy Call</a>
+            </div>
+          </div>
+          <div class="relative isolate overflow-hidden rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-8 text-white shadow-2xl">
+            <div class="absolute -top-20 -right-16 h-40 w-40 rounded-full bg-cyan-400/40 blur-3xl" aria-hidden="true"></div>
+            <div class="absolute -bottom-24 -left-10 h-44 w-44 rounded-full bg-indigo-500/30 blur-3xl" aria-hidden="true"></div>
+            <div class="relative space-y-6">
+              <h3 class="text-2xl font-semibold">Why Brightscale</h3>
+              <ul class="space-y-4 text-sm text-slate-100">
+                <li class="flex items-start gap-3"><span class="mt-1 text-lg">📊</span>Executive-ready insights that tie engineering health to financial impact.</li>
+                <li class="flex items-start gap-3"><span class="mt-1 text-lg">🧭</span>Modular playbooks and accelerators to de-risk platform, security, and delivery transformations.</li>
+                <li class="flex items-start gap-3"><span class="mt-1 text-lg">🧑‍🤝‍🧑</span>Multi-disciplinary teams spanning product, architecture, governance, and change management.</li>
+              </ul>
+              <div class="rounded-2xl bg-white/10 p-4">
+                <p class="text-sm uppercase tracking-wide text-cyan-200">Client Confidence</p>
+                <p class="mt-2 text-3xl font-semibold">96%</p>
+                <p class="text-sm text-slate-200">Engagement satisfaction rating across global programs.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="services" class="space-y-10 rounded-3xl bg-slate-900/95 p-10 text-white shadow-xl">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-sm font-medium text-cyan-200">Core Consulting Pillars</span>
+            <h2 class="mt-4 text-3xl font-semibold">Where We Accelerate Value</h2>
+            <p class="mt-2 max-w-3xl text-slate-200">Our practitioners orchestrate cross-functional change through four tightly integrated service lines. Each pillar blends advisory, hands-on enablement, and accelerators proven in complex environments.</p>
+          </div>
+          <a href="mailto:hello@brightscale.partners" class="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-cyan-500/30 transition hover:bg-cyan-100">Book an Intro Call<span aria-hidden="true">→</span></a>
+        </div>
+        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+          <article class="flex flex-col gap-4 rounded-3xl bg-white/5 p-6 shadow-sm ring-1 ring-white/10">
+            <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-cyan-500/20 text-2xl">🚀</div>
+            <div>
+              <h3 class="text-xl font-semibold">Product Delivery Modernization</h3>
+              <p class="mt-2 text-sm text-slate-200">Scale agile product teams, recalibrate operating models, and accelerate release cadences.</p>
+            </div>
+            <a href="Platform_Engineering.html" class="mt-auto inline-flex items-center gap-2 text-sm font-semibold text-cyan-200 transition hover:text-white">Explore platform insights<span aria-hidden="true">→</span></a>
+          </article>
+          <article class="flex flex-col gap-4 rounded-3xl bg-white/5 p-6 shadow-sm ring-1 ring-white/10">
+            <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-400/20 text-2xl">📊</div>
+            <div>
+              <h3 class="text-xl font-semibold">Technology Financial Management</h3>
+              <p class="mt-2 text-sm text-slate-200">Operationalize FinOps practices that unite engineering and finance around shared KPIs.</p>
+            </div>
+            <a href="FinOps_Summary.html" class="mt-auto inline-flex items-center gap-2 text-sm font-semibold text-cyan-200 transition hover:text-white">See FinOps playbook<span aria-hidden="true">→</span></a>
+          </article>
+          <article class="flex flex-col gap-4 rounded-3xl bg-white/5 p-6 shadow-sm ring-1 ring-white/10">
+            <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-rose-400/20 text-2xl">🛡️</div>
+            <div>
+              <h3 class="text-xl font-semibold">Secure-by-Design Engineering</h3>
+              <p class="mt-2 text-sm text-slate-200">Embed proactive security, governance, and compliance guardrails across pipelines.</p>
+            </div>
+            <a href="Software_Security_Summary.html" class="mt-auto inline-flex items-center gap-2 text-sm font-semibold text-cyan-200 transition hover:text-white">Review security services<span aria-hidden="true">→</span></a>
+          </article>
+          <article class="flex flex-col gap-4 rounded-3xl bg-white/5 p-6 shadow-sm ring-1 ring-white/10">
+            <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-400/20 text-2xl">🔗</div>
+            <div>
+              <h3 class="text-xl font-semibold">Intelligent Delivery Platforms</h3>
+              <p class="mt-2 text-sm text-slate-200">Engineer automated supply chains, observability, and AI-assisted workflows.</p>
+            </div>
+            <a href="Software_Code_Pipeline.html" class="mt-auto inline-flex items-center gap-2 text-sm font-semibold text-cyan-200 transition hover:text-white">Tour delivery accelerators<span aria-hidden="true">→</span></a>
+          </article>
+        </div>
+      </section>
+
+      <section id="industries" class="space-y-10 rounded-3xl bg-white/80 p-10 shadow-xl ring-1 ring-slate-200/60">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <span class="inline-flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-1 text-sm font-medium text-emerald-700">Industries We Serve</span>
+            <h2 class="mt-4 text-3xl font-semibold text-slate-900">Transforming Complex, Regulated Domains</h2>
+            <p class="mt-2 max-w-3xl text-slate-600">We translate modern engineering practices into sector-specific outcomes, navigating compliance, customer expectations, and legacy technology with precision.</p>
+          </div>
+          <a href="mailto:hello@brightscale.partners" class="inline-flex items-center gap-2 rounded-full border border-emerald-500 px-5 py-3 text-sm font-semibold text-emerald-700 transition hover:bg-emerald-500 hover:text-white">Discuss your industry<span aria-hidden="true">→</span></a>
+        </div>
+        <div class="grid gap-6 lg:grid-cols-3">
+          <article class="flex flex-col gap-4 rounded-3xl bg-slate-50 p-6 shadow-sm ring-1 ring-slate-200">
+            <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/15 text-2xl">🏦</div>
+            <h3 class="text-xl font-semibold text-slate-900">Financial Services</h3>
+            <p class="text-sm text-slate-600">Re-platformed digital banking and risk analytics with automated compliance controls.</p>
+            <ul class="space-y-2 text-sm text-slate-500">
+              <li>• 35% reduction in time-to-market for regulatory updates.</li>
+              <li>• Unified reporting cut audit prep cycles by 50%.</li>
+            </ul>
+          </article>
+          <article class="flex flex-col gap-4 rounded-3xl bg-slate-50 p-6 shadow-sm ring-1 ring-slate-200">
+            <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-500/15 text-2xl">🛒</div>
+            <h3 class="text-xl font-semibold text-slate-900">Retail &amp; eCommerce</h3>
+            <p class="text-sm text-slate-600">Modernized omnichannel experiences through data-driven experimentation and platform automation.</p>
+            <ul class="space-y-2 text-sm text-slate-500">
+              <li>• 22% uplift in conversion via iterative product delivery.</li>
+              <li>• Cloud spend variance trimmed by 18% in peak seasons.</li>
+            </ul>
+          </article>
+          <article class="flex flex-col gap-4 rounded-3xl bg-slate-50 p-6 shadow-sm ring-1 ring-slate-200">
+            <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-rose-500/15 text-2xl">🧬</div>
+            <h3 class="text-xl font-semibold text-slate-900">Healthcare &amp; Life Sciences</h3>
+            <p class="text-sm text-slate-600">Enabled secure data pipelines and compliant release practices for clinical platforms.</p>
+            <ul class="space-y-2 text-sm text-slate-500">
+              <li>• 40% faster deployment of validated features.</li>
+              <li>• Zero critical audit findings across annual reviews.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="results" class="space-y-8 rounded-3xl bg-gradient-to-br from-cyan-600 via-sky-600 to-indigo-700 p-10 text-white shadow-xl">
+        <div class="grid gap-10 lg:grid-cols-2 lg:items-center">
+          <div class="space-y-4">
+            <span class="inline-flex items-center gap-2 rounded-full bg-white/15 px-4 py-1 text-sm font-medium uppercase tracking-wide">Client Outcomes</span>
+            <h2 class="text-3xl font-semibold">Proof in the Metrics</h2>
+            <p class="text-lg text-sky-50">Our clients trust us to navigate critical initiatives with rigor and empathy. We co-create measurable success plans and share accountability for the results.</p>
+            <div class="grid gap-4 sm:grid-cols-2">
+              <div class="rounded-3xl bg-white/10 p-5 shadow-lg">
+                <p class="text-4xl font-semibold">48%</p>
+                <p class="mt-1 text-sm text-sky-100">Average increase in deployment frequency within six months.</p>
+              </div>
+              <div class="rounded-3xl bg-white/10 p-5 shadow-lg">
+                <p class="text-4xl font-semibold">30%</p>
+                <p class="mt-1 text-sm text-sky-100">Reduction in critical security findings across platform assessments.</p>
+              </div>
+              <div class="rounded-3xl bg-white/10 p-5 shadow-lg">
+                <p class="text-4xl font-semibold">2.1x</p>
+                <p class="mt-1 text-sm text-sky-100">Return on transformation investments tracked via FinOps KPIs.</p>
+              </div>
+              <div class="rounded-3xl bg-white/10 p-5 shadow-lg">
+                <p class="text-4xl font-semibold"><span class="text-sky-200">#1</span></p>
+                <p class="mt-1 text-sm text-sky-100">Customer satisfaction ranking post launch of new digital experience.</p>
+              </div>
+            </div>
+          </div>
+          <div class="space-y-6 rounded-3xl bg-white/10 p-8 shadow-2xl">
+            <h3 class="text-2xl font-semibold">What Clients Say</h3>
+            <blockquote class="text-lg text-slate-100">“Brightscale embedded with our platform teams, re-architected our delivery pipeline, and brought finance into the conversation. We shipped faster, safer software and built the culture to sustain it.”</blockquote>
+            <cite class="block text-sm uppercase tracking-wide text-sky-200">CTO, Global Retail Brand</cite>
+            <a href="mailto:hello@brightscale.partners" class="inline-flex w-full items-center justify-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-sky-100">Start a conversation<span aria-hidden="true">→</span></a>
+          </div>
+        </div>
+      </section>
+
+      <section id="insights" class="space-y-8">
         <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h2 class="text-2xl font-semibold text-slate-900">Explore the Library</h2>
+            <h2 class="text-2xl font-semibold text-slate-900">Insights Library</h2>
             <p class="mt-2 max-w-3xl text-slate-600">
               Dive into strategy, architecture, operations, and security with curated reports crafted for engineering leaders and
               hands-on builders alike.


### PR DESCRIPTION
## Summary
- add firm overview hero follow-on section detailing differentiators and trust signals
- introduce services, industries, and client results sections with contextual CTAs
- reposition existing resource cards under a secondary Insights Library section

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc348ad314832584b1033b0139351c