### PR TITLE
Link design system styles across report pages

### DIFF
--- a/Software_Code_Pipeline.html
+++ b/Software_Code_Pipeline.html
@@ -26,7 +26,9 @@
             --page-bg: #f8fafc;
             --page-text: #1e293b;
             --home-button-bg: #0ea5e9;
+            --home-button-text: #ffffff;
             --home-button-hover: #0284c7;
+            --home-button-text-hover: #ffffff;
             --home-button-shadow: 0 10px 25px -10px rgba(14, 165, 233, 0.6);
             --home-button-shadow-hover: 0 18px 30px -12px rgba(2, 132, 199, 0.7);
         }

--- a/Software_Security_Detailed.html
+++ b/Software_Security_Detailed.html
@@ -22,7 +22,9 @@
             --nav-item-hover-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
             --nav-item-active-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
             --home-button-bg: #2563EB;
+            --home-button-text: #ffffff;
             --home-button-hover: #1d4ed8;
+            --home-button-text-hover: #ffffff;
             --home-button-shadow: 0 12px 26px -12px rgba(37, 99, 235, 0.6);
             --home-button-shadow-hover: 0 18px 32px -14px rgba(29, 78, 216, 0.7);
         }

--- a/Software_Security_Summary.html
+++ b/Software_Security_Summary.html
@@ -11,20 +11,28 @@
   <link rel="stylesheet" href="styles/brand-header.css">
   <link rel="stylesheet" href="styles/design-system.css">
   <style>
-    :root{
-      --page-bg:#f8fafc;
-      --page-text:#1e293b;
-      --nav-link-accent:#2563EB;
-      --nav-item-border-width:0;
-      --nav-item-radius:0.5rem;
-      --nav-item-hover-bg:#EFF6FF;
-      --nav-item-active-bg:#EFF6FF;
-      --home-button-bg:#2563EB;
-      --home-button-hover:#1d4ed8;
-      --home-button-shadow:0 12px 26px -12px rgba(37,99,235,.6);
-      --home-button-shadow-hover:0 18px 32px -14px rgba(29,78,216,.7);
+    :root {
+      --page-bg: #f8fafc;
+      --page-text: #1e293b;
+      --nav-link-accent: #2563EB;
+      --nav-item-border-width: 0;
+      --nav-item-radius: 0.5rem;
+      --nav-item-hover-bg: #EFF6FF;
+      --nav-item-active-bg: #EFF6FF;
+      --home-button-bg: #2563EB;
+      --home-button-text: #ffffff;
+      --home-button-hover: #1d4ed8;
+      --home-button-text-hover: #ffffff;
+      --home-button-shadow: 0 12px 26px -12px rgba(37, 99, 235, .6);
+      --home-button-shadow-hover: 0 18px 32px -14px rgba(29, 78, 216, .7);
     }
-    .sidebar-nav-item{display:block;padding:.5rem .75rem;border-radius:.5rem;color:#6B7280;transition:background-color .2s ease,color .2s ease}
+    .sidebar-nav-item {
+      display: block;
+      padding: .5rem .75rem;
+      border-radius: .5rem;
+      color: #6B7280;
+      transition: background-color .2s ease, color .2s ease;
+    }
   </style>
 </head>
 <body class="smooth-scroll">

--- a/Software_Suppy_Chain.html
+++ b/Software_Suppy_Chain.html
@@ -15,49 +15,11 @@
             --page-bg: #f8fafc;
             --page-text: #1e293b;
             --home-button-bg: #2563EB;
+            --home-button-text: #ffffff;
             --home-button-hover: #1d4ed8;
+            --home-button-text-hover: #ffffff;
             --home-button-shadow: 0 12px 26px -12px rgba(37, 99, 235, 0.6);
             --home-button-shadow-hover: 0 18px 32px -14px rgba(29, 78, 216, 0.7);
-        }
-        .container {
-            max-width: 900px;
-            margin: 0 auto;
-            padding: 2rem;
-        }
-        h1, h2, h3 {
-            color: #1a202c;
-            font-weight: 700;
-        }
-        h1 {
-            font-size: 2.5rem;
-            margin-bottom: 1.5rem;
-            text-align: center;
-        }
-        h2 {
-            font-size: 2rem;
-            margin-top: 2rem;
-            margin-bottom: 1rem;
-            border-bottom: 2px solid #e2e8f0;
-            padding-bottom: 0.5rem;
-        }
-        h3 {
-            font-size: 1.5rem;
-            margin-top: 1.5rem;
-            margin-bottom: 0.75rem;
-        }
-        p {
-            margin-bottom: 1rem;
-        }
-        ul {
-            list-style-type: disc;
-            margin-left: 1.5rem;
-            margin-bottom: 1rem;
-        }
-        li {
-            margin-bottom: 0.5rem;
-        }
-        strong {
-            font-weight: 600;
         }
         .section-separator {
             border: 0;
@@ -106,7 +68,7 @@
     </header>
     <!-- Navigation Bar -->
     <nav class="bg-gray-800 p-4 shadow-md sticky top-0 z-50 rounded-lg">
-        <div class="container mx-auto flex flex-col md:flex-row items-center justify-between">
+        <div class="max-w-6xl w-full mx-auto flex flex-col md:flex-row items-center justify-between">
             <div class="flex items-center justify-between w-full md:w-auto mb-4 md:mb-0 gap-3">
                 <div class="flex items-center gap-3">
                     <a href="#" class="text-white text-2xl font-bold rounded-md hover:text-blue-300 transition-colors duration-200">Supply Chain Security</a>
@@ -139,7 +101,7 @@
         </div>
     </nav>
 
-    <div class="container bg-white shadow-lg rounded-lg p-8 mt-8 mb-8">
+    <div class="max-w-5xl mx-auto bg-white shadow-lg rounded-lg p-8 mt-8 mb-8">
         <header class="text-center mb-8">
             <h1 class="text-4xl font-extrabold text-gray-900 leading-tight">Software Supply Chain Security in 2024–2025: Risks, Strategies, and Trends</h1>
             <p class="text-gray-600 text-lg mt-2">An overview of the evolving landscape of software supply chain security.</p>

--- a/State_of_Modern_Unit_Testing.html
+++ b/State_of_Modern_Unit_Testing.html
@@ -9,6 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles/brand-header.css">
     <link rel="stylesheet" href="styles/design-system.css">
     <!-- Chosen Palette: Warm Neutrals & Sage -->
     <!-- Application Structure Plan: A tab-based navigation SPA is chosen to segment complex information into digestible, user-selectable themes: Overview, Core Practices, Toolbox, Future Forward, and Key Metrics. This non-linear structure empowers users to explore topics based on their interest, rather than forcing a linear progression. The flow starts with a high-level summary (Overview) and then allows deep dives into methodologies, tools, and performance measurement. This enhances usability by preventing information overload and providing clear pathways to specific content, making a dense topic approachable for developers, managers, and students alike. -->
@@ -26,7 +27,9 @@
             --page-text: #4A4A4A;
             --nav-link-accent: #38A89D;
             --home-button-bg: #38A89D;
+            --home-button-text: #ffffff;
             --home-button-hover: #2f9c91;
+            --home-button-text-hover: #ffffff;
             --home-button-shadow: 0 12px 26px -12px rgba(56, 168, 157, 0.55);
             --home-button-shadow-hover: 0 18px 32px -14px rgba(47, 156, 145, 0.65);
         }


### PR DESCRIPTION
## Summary
- add the shared design-system stylesheet after the brand header include across the pipeline, security, supply chain, and unit testing reports
- reduce page-level style blocks to custom property definitions and page-specific rules while keeping existing interactive layouts intact

## Testing
- not run (static HTML changes)


------
https://chatgpt.com/codex/tasks/task_e_68cce85228b08325b70c8d1843252875