### PR TITLE
Add consultation CTAs and expand contact experience

### DIFF
--- a/Design_Thinking_in_SDLC.html
+++ b/Design_Thinking_in_SDLC.html
@@ -123,11 +123,11 @@
       <nav class="brand-header__nav" aria-label="Primary">
         <a class="brand-header__link" href="index.html#services">Services</a>
         <a class="brand-header__link" href="index.html#industries">Industries</a>
-        <a class="brand-header__link" href="index.html#explore">Insights</a>
+        <a class="brand-header__link" href="index.html#insights">Insights</a>
         <a class="brand-header__link" href="index.html#about">About</a>
         <a class="brand-header__link" href="index.html#contact">Contact</a>
       </nav>
-      <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+      <a class="brand-header__cta" href="index.html#contact">Schedule a Consultation</a>
     </div>
   </header>
   <div class="pt-6 sm:pt-8 lg:pt-12">
@@ -155,6 +155,19 @@
     <section id="intro" class="card">
       <h1>Design Thinking in Modern Software Engineering: Current Practices Across All Development Phases</h1>
       <p>Design Thinking (DT) is a human-centered approach to problem-solving that has been increasingly adopted in software engineering. It emphasizes understanding user needs, creative ideation, prototyping, and testing to ensure solutions are innovative and user-centric. Modern software teams are putting the user at the center of development with approaches like DT to drive better outcomes<sup class="citation">:contentReference[oaicite:0]{index=0}</sup>. This report explores how Design Thinking is applied throughout all phases of the software development lifecycle, highlighting current practices and integration strategies.</p>
+    </section>
+    <section aria-labelledby="design-thinking-engage" class="card" style="background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(14, 116, 144, 0.9)); color: #f8fafc;">
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div class="space-y-3 max-w-2xl">
+          <p class="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200">Partner with Brightscale</p>
+          <h2 id="design-thinking-engage" class="text-2xl font-semibold">Bring human-centered software strategy to life</h2>
+          <p class="text-slate-200">Our advisory squads design customer journeys, facilitate co-creation workshops, and embed change agents so your product and platform teams deliver with clarity.</p>
+        </div>
+        <div class="flex flex-col gap-3 md:items-end">
+          <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-cyan-100/80">Schedule a Consultation</a>
+          <a href="mailto:hello@brightscale.partners" class="text-sm font-medium text-cyan-100 transition hover:text-white">hello@brightscale.partners</a>
+        </div>
+      </div>
     </section>
     <section id="background" class="card">
       <h2>Background: The Design Thinking Process</h2>
@@ -316,10 +329,49 @@
       }
     });
   </script>
-  <footer class="bg-slate-900 text-slate-100 py-6 mt-16">
-    <div class="max-w-6xl mx-auto px-6 text-sm text-center sm:text-left sm:flex sm:items-center sm:justify-between gap-4">
-      <span>© 2024 Software Engineering Knowledge Hub. All rights reserved.</span>
-      <a href="index.html" class="text-slate-300 transition hover:text-white">Back to home ↗</a>
+  <footer class="bg-slate-950 text-slate-100 mt-16">
+    <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+      <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+        <div class="space-y-4">
+          <div class="flex items-center gap-3">
+            <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-cyan-400/20 text-lg font-semibold text-cyan-200">SE</span>
+            <div class="text-sm">
+              <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+              <p class="text-slate-300">Software Advisory &amp; Transformation</p>
+            </div>
+          </div>
+          <p class="text-sm leading-relaxed text-slate-400">We align product, design, and engineering teams around empathetic discovery and measurable delivery outcomes.</p>
+        </div>
+        <div class="space-y-4">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Offices</h3>
+          <ul class="space-y-3 text-sm text-slate-300">
+            <li><span class="font-semibold text-white">San Francisco</span> — 575 Market Street, Suite 3200</li>
+            <li><span class="font-semibold text-white">New York</span> — 85 Broad Street, 28th Floor</li>
+            <li><span class="font-semibold text-white">London</span> — 1 Finsbury Avenue, Level 4</li>
+          </ul>
+        </div>
+        <div class="space-y-4">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Connect</h3>
+          <p class="text-sm text-slate-300">Call <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a> or email <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+          <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-cyan-100/80">Schedule a Consultation</a>
+        </div>
+        <div class="space-y-4">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Social Proof</h3>
+          <div class="flex flex-wrap gap-3">
+            <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">G2 High Performer</span>
+            <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">Cloud Verified Partner</span>
+            <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">ISO 27001 Ready</span>
+          </div>
+        </div>
+      </div>
+      <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+        <p>© 2024 Brightscale Partners. All rights reserved.</p>
+        <div class="flex flex-wrap gap-6">
+          <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
+          <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
+          <a href="#" class="transition hover:text-slate-200">Code of Conduct</a>
+        </div>
+      </div>
     </div>
   </footer>
 </body>

--- a/FinOps_Detailed.html
+++ b/FinOps_Detailed.html
@@ -118,11 +118,11 @@
             <nav class="brand-header__nav" aria-label="Primary">
                 <a class="brand-header__link" href="index.html#services">Services</a>
                 <a class="brand-header__link" href="index.html#industries">Industries</a>
-                <a class="brand-header__link" href="index.html#explore">Insights</a>
+                <a class="brand-header__link" href="index.html#insights">Insights</a>
                 <a class="brand-header__link" href="index.html#about">About</a>
                 <a class="brand-header__link" href="index.html#contact">Contact</a>
             </nav>
-            <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+            <a class="brand-header__cta" href="index.html#contact">Schedule a Consultation</a>
         </div>
     </header>
 
@@ -169,6 +169,20 @@
                 <section id="introduction" class="mb-12">
                     <h2 class="section-heading mb-4 text-3xl font-bold text-gray-800">Introduction</h2>
                     <p class="mb-4"><strong>FinOps (Financial Operations)</strong> has rapidly evolved into a critical discipline for managing cloud and technology spend. With worldwide cloud expenditures projected to exceed $825 billion in 2025, organizations are adopting FinOps to ensure every dollar is well-spent. FinOps is defined as “an operational framework and cultural practice which maximizes the business value of cloud, enables timely data-driven decision making, and creates financial accountability through collaboration between engineering, finance, and business teams.” This report examines the current state of FinOps in 2025, including adoption trends, challenges, best practices, tooling, and real-world case studies.</p>
+                </section>
+
+                <section aria-labelledby="finops-detailed-engage" class="mb-12">
+                    <div class="rounded-3xl bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 px-8 py-10 text-white shadow-xl flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                        <div class="space-y-3 max-w-2xl">
+                            <p class="text-sm font-semibold uppercase tracking-[0.35em] text-blue-200">Partner with Brightscale</p>
+                            <h2 id="finops-detailed-engage" class="text-2xl lg:text-3xl font-semibold">Need help activating these FinOps playbooks?</h2>
+                            <p class="text-slate-100/80">We embed with finance, product, and platform leaders to establish guardrails, dashboards, and behaviors that sustain spend efficiency.</p>
+                        </div>
+                        <div class="flex flex-col gap-3 lg:items-end">
+                            <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-blue-100/70">Schedule a Consultation</a>
+                            <a href="mailto:hello@brightscale.partners" class="text-sm font-medium text-blue-100 transition hover:text-white">hello@brightscale.partners</a>
+                        </div>
+                    </div>
                 </section>
 
                 <hr class="border-gray-200 my-8">
@@ -423,10 +437,49 @@
         window.addEventListener('scroll', highlightNavItem);
         document.addEventListener('DOMContentLoaded', highlightNavItem); // Highlight on load
     </script>
-    <footer class="bg-slate-900 text-slate-100 py-6 mt-16">
-        <div class="max-w-6xl mx-auto px-6 text-sm text-center sm:text-left sm:flex sm:items-center sm:justify-between gap-4">
-            <span>© 2024 Software Engineering Knowledge Hub. All rights reserved.</span>
-            <a href="index.html" class="text-slate-300 transition hover:text-white">Back to home ↗</a>
+    <footer class="bg-slate-950 text-slate-100 mt-16">
+        <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+            <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+                <div class="space-y-4">
+                    <div class="flex items-center gap-3">
+                        <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-blue-400/20 text-lg font-semibold text-blue-200">SE</span>
+                        <div class="text-sm">
+                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="text-slate-300">Software Advisory &amp; Transformation</p>
+                        </div>
+                    </div>
+                    <p class="text-sm leading-relaxed text-slate-400">We guide technology leaders through FinOps, platform, and security transformations with measurable business impact.</p>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Offices</h3>
+                    <ul class="space-y-3 text-sm text-slate-300">
+                        <li><span class="font-semibold text-white">San Francisco</span> — 575 Market Street, Suite 3200</li>
+                        <li><span class="font-semibold text-white">New York</span> — 85 Broad Street, 28th Floor</li>
+                        <li><span class="font-semibold text-white">London</span> — 1 Finsbury Avenue, Level 4</li>
+                    </ul>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Connect</h3>
+                    <p class="text-sm text-slate-300">Call <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a> or email <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+                    <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-blue-100/70">Schedule a Consultation</a>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Social Proof</h3>
+                    <div class="flex flex-wrap gap-3">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">G2 High Performer</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">Cloud Verified Partner</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">ISO 27001 Ready</span>
+                    </div>
+                </div>
+            </div>
+            <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <div class="flex flex-wrap gap-6">
+                    <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
+                    <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
+                    <a href="#" class="transition hover:text-slate-200">Code of Conduct</a>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/FinOps_Summary.html
+++ b/FinOps_Summary.html
@@ -44,11 +44,11 @@
     <nav class="brand-header__nav" aria-label="Primary">
       <a class="brand-header__link" href="index.html#services">Services</a>
       <a class="brand-header__link" href="index.html#industries">Industries</a>
-      <a class="brand-header__link" href="index.html#explore">Insights</a>
+      <a class="brand-header__link" href="index.html#insights">Insights</a>
       <a class="brand-header__link" href="index.html#about">About</a>
       <a class="brand-header__link" href="index.html#contact">Contact</a>
     </nav>
-    <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+    <a class="brand-header__cta" href="index.html#contact">Schedule a Consultation</a>
   </div>
 </header>
 
@@ -97,6 +97,20 @@
       <a href="#tooling" class="px-6 py-3 bg-white text-amber-600 border border-amber-500 rounded-xl font-semibold hover:bg-amber-50">
         See Tools & Vendors
       </a>
+    </div>
+  </section>
+
+  <section aria-labelledby="finops-engage" class="py-10">
+    <div class="rounded-3xl bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 px-8 py-10 text-white shadow-xl flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+      <div class="space-y-3 max-w-2xl">
+        <p class="text-sm font-semibold uppercase tracking-[0.35em] text-amber-200">Partner with Brightscale</p>
+        <h2 id="finops-engage" class="text-2xl md:text-3xl font-semibold">Ready to operationalize FinOps across your teams?</h2>
+        <p class="text-slate-100/80">Our advisors stand up governance rhythms, align finance and engineering, and build dashboards your executives trust.</p>
+      </div>
+      <div class="flex flex-col gap-3 md:items-end">
+        <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-amber-100/80">Schedule a Consultation</a>
+        <a href="mailto:hello@brightscale.partners" class="text-sm font-medium text-amber-100 transition hover:text-white">hello@brightscale.partners</a>
+      </div>
     </div>
   </section>
 
@@ -269,10 +283,49 @@
 
 </main>
 
-<footer class="bg-slate-800 text-slate-300 py-8">
-  <div class="container mx-auto text-center">
-    <p>FinOps, Explained — 2025 Executive Guide</p>
-    <p class="text-sm text-slate-400 mt-2">Summarized from a comprehensive research report. For education only.</p>
+<footer class="bg-slate-950 text-slate-100 mt-16">
+  <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+    <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+      <div class="space-y-4">
+        <div class="flex items-center gap-3">
+          <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-amber-400/20 text-lg font-semibold text-amber-200">SE</span>
+          <div class="text-sm">
+            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+            <p class="text-slate-300">Software Advisory &amp; Transformation</p>
+          </div>
+        </div>
+        <p class="text-sm leading-relaxed text-slate-400">FinOps, platform, and security leaders trust us to deliver measurable outcomes and executive-ready storytelling.</p>
+      </div>
+      <div class="space-y-4">
+        <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Offices</h3>
+        <ul class="space-y-3 text-sm text-slate-300">
+          <li><span class="font-semibold text-white">San Francisco</span> — 575 Market Street, Suite 3200</li>
+          <li><span class="font-semibold text-white">New York</span> — 85 Broad Street, 28th Floor</li>
+          <li><span class="font-semibold text-white">London</span> — 1 Finsbury Avenue, Level 4</li>
+        </ul>
+      </div>
+      <div class="space-y-4">
+        <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Connect</h3>
+        <p class="text-sm text-slate-300">Call <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a> or email <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+        <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-amber-100/80">Schedule a Consultation</a>
+      </div>
+      <div class="space-y-4">
+        <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Social Proof</h3>
+        <div class="flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">G2 High Performer</span>
+          <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">Cloud Verified Partner</span>
+          <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">ISO 27001 Ready</span>
+        </div>
+      </div>
+    </div>
+    <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+      <p>© 2024 Brightscale Partners. All rights reserved.</p>
+      <div class="flex flex-wrap gap-6">
+        <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
+        <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
+        <a href="#" class="transition hover:text-slate-200">Code of Conduct</a>
+      </div>
+    </div>
   </div>
 </footer>
 
@@ -467,11 +520,5 @@ document.addEventListener('DOMContentLoaded', () => {
   mobileNav.addEventListener('change', e => { window.location.hash = e.target.value; });
 });
 </script>
-<footer class="bg-slate-900 text-slate-100 py-6 mt-16">
-  <div class="max-w-6xl mx-auto px-6 text-sm text-center sm:text-left sm:flex sm:items-center sm:justify-between gap-4">
-    <span>© 2024 Software Engineering Knowledge Hub. All rights reserved.</span>
-    <a href="index.html" class="text-slate-300 transition hover:text-white">Back to home ↗</a>
-  </div>
-</footer>
 </body>
 </html>

--- a/Platform_Engineering.html
+++ b/Platform_Engineering.html
@@ -76,11 +76,11 @@
             <nav class="brand-header__nav" aria-label="Primary">
                 <a class="brand-header__link" href="index.html#services">Services</a>
                 <a class="brand-header__link" href="index.html#industries">Industries</a>
-                <a class="brand-header__link" href="index.html#explore">Insights</a>
+                <a class="brand-header__link" href="index.html#insights">Insights</a>
                 <a class="brand-header__link" href="index.html#about">About</a>
                 <a class="brand-header__link" href="index.html#contact">Contact</a>
             </nav>
-            <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+            <a class="brand-header__cta" href="index.html#contact">Schedule a Consultation</a>
         </div>
     </header>
 
@@ -124,6 +124,20 @@
             <p class="max-w-3xl mx-auto text-lg text-slate-600">
                 Platform engineering has emerged as a vital discipline to manage the overwhelming complexity of modern software development. This interactive report explores its core principles, market adoption, strategic impact, and future trajectory, translating key research findings into an explorable experience.
             </p>
+        </section>
+
+        <section aria-labelledby="platform-engage" class="mb-24">
+            <div class="rounded-3xl bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 px-8 py-10 text-white shadow-xl flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                <div class="space-y-3 max-w-2xl text-left lg:text-left">
+                    <p class="text-sm font-semibold uppercase tracking-[0.35em] text-sky-200">Partner with Brightscale</p>
+                    <h2 id="platform-engage" class="text-2xl lg:text-3xl font-semibold">Building an internal developer platform or boosting adoption?</h2>
+                    <p class="text-slate-100/80">Brightscale advisors craft golden-path roadmaps, align product and platform leaders, and deliver the change enablement required for sustainable adoption.</p>
+                </div>
+                <div class="flex flex-col gap-3 lg:items-end">
+                    <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-sky-100/70">Schedule a Consultation</a>
+                    <a href="mailto:hello@brightscale.partners" class="text-sm font-medium text-sky-100 transition hover:text-white">hello@brightscale.partners</a>
+                </div>
+            </div>
         </section>
 
         <!-- Section 2: Market Size and Adoption -->
@@ -433,10 +447,49 @@
             updateComparativeContent('primaryGoal');
         });
     </script>
-    <footer class="bg-slate-900 text-slate-100 py-6 mt-16">
-        <div class="max-w-6xl mx-auto px-6 text-sm text-center sm:text-left sm:flex sm:items-center sm:justify-between gap-4">
-            <span>© 2024 Software Engineering Knowledge Hub. All rights reserved.</span>
-            <a href="index.html" class="text-slate-300 transition hover:text-white">Back to home ↗</a>
+    <footer class="bg-slate-950 text-slate-100 mt-16">
+        <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+            <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+                <div class="space-y-4">
+                    <div class="flex items-center gap-3">
+                        <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-sky-400/20 text-lg font-semibold text-sky-200">SE</span>
+                        <div class="text-sm">
+                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="text-slate-300">Software Advisory &amp; Transformation</p>
+                        </div>
+                    </div>
+                    <p class="text-sm leading-relaxed text-slate-400">We design platform strategies, build operating models, and mentor teams through the adoption curve.</p>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Offices</h3>
+                    <ul class="space-y-3 text-sm text-slate-300">
+                        <li><span class="font-semibold text-white">San Francisco</span> — 575 Market Street, Suite 3200</li>
+                        <li><span class="font-semibold text-white">New York</span> — 85 Broad Street, 28th Floor</li>
+                        <li><span class="font-semibold text-white">London</span> — 1 Finsbury Avenue, Level 4</li>
+                    </ul>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Connect</h3>
+                    <p class="text-sm text-slate-300">Call <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a> or email <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+                    <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-sky-100/70">Schedule a Consultation</a>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Social Proof</h3>
+                    <div class="flex flex-wrap gap-3">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">G2 High Performer</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">Cloud Verified Partner</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">ISO 27001 Ready</span>
+                    </div>
+                </div>
+            </div>
+            <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <div class="flex flex-wrap gap-6">
+                    <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
+                    <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
+                    <a href="#" class="transition hover:text-slate-200">Code of Conduct</a>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/Software_Code_Pipeline.html
+++ b/Software_Code_Pipeline.html
@@ -89,11 +89,11 @@
             <nav class="brand-header__nav" aria-label="Primary">
                 <a class="brand-header__link" href="index.html#services">Services</a>
                 <a class="brand-header__link" href="index.html#industries">Industries</a>
-                <a class="brand-header__link" href="index.html#explore">Insights</a>
+                <a class="brand-header__link" href="index.html#insights">Insights</a>
                 <a class="brand-header__link" href="index.html#about">About</a>
                 <a class="brand-header__link" href="index.html#contact">Contact</a>
             </nav>
-            <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+            <a class="brand-header__cta" href="index.html#contact">Schedule a Consultation</a>
         </div>
     </header>
     <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -104,6 +104,20 @@
             <h1 class="text-4xl md:text-5xl font-bold text-slate-900">The Modern Software Code Pipeline</h1>
             <p class="mt-4 text-lg text-slate-600 max-w-3xl mx-auto">An interactive journey from a line of code to a live feature in production. Click on any stage below to explore it in detail.</p>
         </header>
+
+        <section aria-labelledby="pipeline-engage" class="mb-12">
+            <div class="rounded-3xl bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 px-8 py-10 text-white shadow-xl flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                <div class="space-y-3 max-w-2xl text-left">
+                    <p class="text-sm font-semibold uppercase tracking-[0.35em] text-sky-200">Partner with Brightscale</p>
+                    <h2 id="pipeline-engage" class="text-2xl lg:text-3xl font-semibold">Need a delivery pipeline built for speed and safety?</h2>
+                    <p class="text-slate-100/80">Our team designs automated guardrails, integrates security and FinOps controls, and coaches squads so high-quality releases become routine.</p>
+                </div>
+                <div class="flex flex-col gap-3 lg:items-end">
+                    <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-sky-100/70">Schedule a Consultation</a>
+                    <a href="mailto:hello@brightscale.partners" class="text-sm font-medium text-sky-100 transition hover:text-white">hello@brightscale.partners</a>
+                </div>
+            </div>
+        </section>
 
         <nav id="pipeline-nav" class="mb-12">
             <div class="flex flex-col md:flex-row items-center justify-between gap-4">
@@ -374,10 +388,49 @@
             updateContent('collaborate');
         });
     </script>
-    <footer class="bg-slate-900 text-slate-100 py-6 mt-16">
-        <div class="max-w-6xl mx-auto px-6 text-sm text-center sm:text-left sm:flex sm:items-center sm:justify-between gap-4">
-            <span>© 2024 Software Engineering Knowledge Hub. All rights reserved.</span>
-            <a href="index.html" class="text-slate-300 transition hover:text-white">Back to home ↗</a>
+    <footer class="bg-slate-950 text-slate-100 mt-16">
+        <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+            <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+                <div class="space-y-4">
+                    <div class="flex items-center gap-3">
+                        <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-sky-400/20 text-lg font-semibold text-sky-200">SE</span>
+                        <div class="text-sm">
+                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="text-slate-300">Software Advisory &amp; Transformation</p>
+                        </div>
+                    </div>
+                    <p class="text-sm leading-relaxed text-slate-400">We architect CI/CD operating models, platform guardrails, and SRE practices that keep releases fast and dependable.</p>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Offices</h3>
+                    <ul class="space-y-3 text-sm text-slate-300">
+                        <li><span class="font-semibold text-white">San Francisco</span> — 575 Market Street, Suite 3200</li>
+                        <li><span class="font-semibold text-white">New York</span> — 85 Broad Street, 28th Floor</li>
+                        <li><span class="font-semibold text-white">London</span> — 1 Finsbury Avenue, Level 4</li>
+                    </ul>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Connect</h3>
+                    <p class="text-sm text-slate-300">Call <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a> or email <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+                    <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-sky-100/70">Schedule a Consultation</a>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Social Proof</h3>
+                    <div class="flex flex-wrap gap-3">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">G2 High Performer</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">Cloud Verified Partner</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">ISO 27001 Ready</span>
+                    </div>
+                </div>
+            </div>
+            <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <div class="flex flex-wrap gap-6">
+                    <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
+                    <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
+                    <a href="#" class="transition hover:text-slate-200">Code of Conduct</a>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/Software_Security_Detailed.html
+++ b/Software_Security_Detailed.html
@@ -120,11 +120,11 @@
             <nav class="brand-header__nav" aria-label="Primary">
                 <a class="brand-header__link" href="index.html#services">Services</a>
                 <a class="brand-header__link" href="index.html#industries">Industries</a>
-                <a class="brand-header__link" href="index.html#explore">Insights</a>
+                <a class="brand-header__link" href="index.html#insights">Insights</a>
                 <a class="brand-header__link" href="index.html#about">About</a>
                 <a class="brand-header__link" href="index.html#contact">Contact</a>
             </nav>
-            <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+            <a class="brand-header__cta" href="index.html#contact">Schedule a Consultation</a>
         </div>
     </header>
 
@@ -175,6 +175,20 @@
                     <h2 class="section-heading mb-4 text-3xl font-bold text-gray-800">Introduction</h2>
                     <p class="mb-4"><strong>Software Security Assurance</strong> has emerged as a critical discipline in an era where cyber threats are ubiquitous and software underpins nearly every business. With global cybercrime costs projected to reach <strong>$10.5 trillion by 2025</strong>, organizations are increasingly focusing on building security into software from the start to prevent costly breaches. Software Security Assurance (SSA) is defined as an approach to designing, developing, and maintaining software with security built in, ensuring applications perform as intended without introducing vulnerabilities. This interactive report examines the state of software security and assurance in 2025, covering adoption trends, challenges, best practices, tools, industry insights, and real-world case studies in securing software systems.</p>
                     <p class="mb-4">In 2025, the stakes for software security are higher than ever. High-profile incidents – from supply chain attacks to zero-day exploits – have driven home the need for proactive security throughout the software lifecycle. Regulatory bodies are also mandating stricter software assurance measures (for example, requirements for software bills of materials and secure development processes). Against this backdrop, we explore how organizations worldwide are integrating security into their development culture (DevSecOps), what challenges persist in scaling these efforts, and how leaders are measuring success. The goal is to provide a comprehensive snapshot of how far software security assurance has come and where it is heading.</p>
+                </section>
+
+                <section aria-labelledby="security-detailed-engage" class="mb-12">
+                    <div class="rounded-3xl bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 px-8 py-10 text-white shadow-xl flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                        <div class="space-y-3 max-w-2xl text-left">
+                            <p class="text-sm font-semibold uppercase tracking-[0.35em] text-blue-200">Partner with Brightscale</p>
+                            <h2 id="security-detailed-engage" class="text-2xl lg:text-3xl font-semibold">Accelerate secure-by-design transformations with a trusted guide</h2>
+                            <p class="text-slate-100/80">We build executive-ready roadmaps, implement DevSecOps guardrails, and stand up continuous compliance so your teams can ship with confidence.</p>
+                        </div>
+                        <div class="flex flex-col gap-3 lg:items-end">
+                            <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-blue-100/70">Schedule a Consultation</a>
+                            <a href="mailto:hello@brightscale.partners" class="text-sm font-medium text-blue-100 transition hover:text-white">hello@brightscale.partners</a>
+                        </div>
+                    </div>
                 </section>
 
                 <hr class="border-gray-200 my-8">
@@ -421,10 +435,49 @@
         window.addEventListener('scroll', highlightNavItem);
         document.addEventListener('DOMContentLoaded', highlightNavItem); // Highlight on load
     </script>
-    <footer class="bg-slate-900 text-slate-100 py-6 mt-16">
-        <div class="max-w-6xl mx-auto px-6 text-sm text-center sm:text-left sm:flex sm:items-center sm:justify-between gap-4">
-            <span>© 2024 Software Engineering Knowledge Hub. All rights reserved.</span>
-            <a href="index.html" class="text-slate-300 transition hover:text-white">Back to home ↗</a>
+    <footer class="bg-slate-950 text-slate-100 mt-16">
+        <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+            <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+                <div class="space-y-4">
+                    <div class="flex items-center gap-3">
+                        <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-blue-400/20 text-lg font-semibold text-blue-200">SE</span>
+                        <div class="text-sm">
+                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="text-slate-300">Software Advisory &amp; Transformation</p>
+                        </div>
+                    </div>
+                    <p class="text-sm leading-relaxed text-slate-400">We embed with engineering, security, and compliance leaders to build resilient software supply chains and measurable assurance programs.</p>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Offices</h3>
+                    <ul class="space-y-3 text-sm text-slate-300">
+                        <li><span class="font-semibold text-white">San Francisco</span> — 575 Market Street, Suite 3200</li>
+                        <li><span class="font-semibold text-white">New York</span> — 85 Broad Street, 28th Floor</li>
+                        <li><span class="font-semibold text-white">London</span> — 1 Finsbury Avenue, Level 4</li>
+                    </ul>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Connect</h3>
+                    <p class="text-sm text-slate-300">Call <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a> or email <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+                    <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-blue-100/70">Schedule a Consultation</a>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Social Proof</h3>
+                    <div class="flex flex-wrap gap-3">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">G2 High Performer</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">Cloud Verified Partner</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">ISO 27001 Ready</span>
+                    </div>
+                </div>
+            </div>
+            <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <div class="flex flex-wrap gap-6">
+                    <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
+                    <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
+                    <a href="#" class="transition hover:text-slate-200">Code of Conduct</a>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/Software_Security_Summary.html
+++ b/Software_Security_Summary.html
@@ -48,11 +48,11 @@
       <nav class="brand-header__nav" aria-label="Primary">
         <a class="brand-header__link" href="index.html#services">Services</a>
         <a class="brand-header__link" href="index.html#industries">Industries</a>
-        <a class="brand-header__link" href="index.html#explore">Insights</a>
+        <a class="brand-header__link" href="index.html#insights">Insights</a>
         <a class="brand-header__link" href="index.html#about">About</a>
         <a class="brand-header__link" href="index.html#contact">Contact</a>
       </nav>
-      <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+      <a class="brand-header__cta" href="index.html#contact">Schedule a Consultation</a>
     </div>
   </header>
   <div class="min-h-screen lg:flex">
@@ -100,6 +100,20 @@
             <li>Finance leads in maturity; healthcare and public sector improving but hampered by legacy tech.</li>
             <li>Emerging shifts: AI-assisted defense/dev, Zero-Trust defaults, SBOM ubiquity, post-quantum crypto transition.</li>
           </ul>
+        </section>
+
+        <section aria-labelledby="security-engage" class="mb-10">
+          <div class="rounded-3xl bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 px-8 py-10 text-white shadow-xl flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div class="space-y-3 max-w-2xl text-left">
+              <p class="text-sm font-semibold uppercase tracking-[0.35em] text-blue-200">Partner with Brightscale</p>
+              <h2 id="security-engage" class="text-2xl lg:text-3xl font-semibold">Need to harden your software supply chain and assurance program?</h2>
+              <p class="text-slate-100/80">Our specialists build DevSecOps guardrails, align global compliance, and run readiness workshops so you can demonstrate resilience to boards and regulators.</p>
+            </div>
+            <div class="flex flex-col gap-3 lg:items-end">
+              <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-blue-100/70">Schedule a Consultation</a>
+              <a href="mailto:hello@brightscale.partners" class="text-sm font-medium text-blue-100 transition hover:text-white">hello@brightscale.partners</a>
+            </div>
+          </div>
         </section>
 
         <section id="threats" class="section mb-8">
@@ -193,10 +207,49 @@
       nav.forEach(a=>a.classList.toggle('active',a.getAttribute('href').slice(1)===current));};
     document.addEventListener('scroll',onScroll,{passive:true});onScroll();
   </script>
-  <footer class="bg-slate-900 text-slate-100 py-6 mt-16">
-    <div class="max-w-6xl mx-auto px-6 text-sm text-center sm:text-left sm:flex sm:items-center sm:justify-between gap-4">
-      <span>© 2024 Software Engineering Knowledge Hub. All rights reserved.</span>
-      <a href="index.html" class="text-slate-300 transition hover:text-white">Back to home ↗</a>
+  <footer class="bg-slate-950 text-slate-100 mt-16">
+    <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+      <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+        <div class="space-y-4">
+          <div class="flex items-center gap-3">
+            <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-blue-400/20 text-lg font-semibold text-blue-200">SE</span>
+            <div class="text-sm">
+              <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+              <p class="text-slate-300">Software Advisory &amp; Transformation</p>
+            </div>
+          </div>
+          <p class="text-sm leading-relaxed text-slate-400">We help CISOs and engineering leaders operationalize secure-by-design practices and prove compliance without slowing delivery.</p>
+        </div>
+        <div class="space-y-4">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Offices</h3>
+          <ul class="space-y-3 text-sm text-slate-300">
+            <li><span class="font-semibold text-white">San Francisco</span> — 575 Market Street, Suite 3200</li>
+            <li><span class="font-semibold text-white">New York</span> — 85 Broad Street, 28th Floor</li>
+            <li><span class="font-semibold text-white">London</span> — 1 Finsbury Avenue, Level 4</li>
+          </ul>
+        </div>
+        <div class="space-y-4">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Connect</h3>
+          <p class="text-sm text-slate-300">Call <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a> or email <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+          <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-blue-100/70">Schedule a Consultation</a>
+        </div>
+        <div class="space-y-4">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Social Proof</h3>
+          <div class="flex flex-wrap gap-3">
+            <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">G2 High Performer</span>
+            <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">Cloud Verified Partner</span>
+            <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">ISO 27001 Ready</span>
+          </div>
+        </div>
+      </div>
+      <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+        <p>© 2024 Brightscale Partners. All rights reserved.</p>
+        <div class="flex flex-wrap gap-6">
+          <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
+          <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
+          <a href="#" class="transition hover:text-slate-200">Code of Conduct</a>
+        </div>
+      </div>
     </div>
   </footer>
 </body>

--- a/Software_Suppy_Chain.html
+++ b/Software_Suppy_Chain.html
@@ -59,11 +59,11 @@
             <nav class="brand-header__nav" aria-label="Primary">
                 <a class="brand-header__link" href="index.html#services">Services</a>
                 <a class="brand-header__link" href="index.html#industries">Industries</a>
-                <a class="brand-header__link" href="index.html#explore">Insights</a>
+                <a class="brand-header__link" href="index.html#insights">Insights</a>
                 <a class="brand-header__link" href="index.html#about">About</a>
                 <a class="brand-header__link" href="index.html#contact">Contact</a>
             </nav>
-            <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+            <a class="brand-header__cta" href="index.html#contact">Schedule a Consultation</a>
         </div>
     </header>
     <!-- Navigation Bar -->
@@ -106,6 +106,20 @@
             <h1 class="text-4xl font-extrabold text-gray-900 leading-tight">Software Supply Chain Security in 2024–2025: Risks, Strategies, and Trends</h1>
             <p class="text-gray-600 text-lg mt-2">An overview of the evolving landscape of software supply chain security.</p>
         </header>
+
+        <section aria-labelledby="supply-chain-engage" class="mb-10">
+            <div class="rounded-3xl bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 px-8 py-10 text-white shadow-xl flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                <div class="space-y-3 max-w-2xl text-left">
+                    <p class="text-sm font-semibold uppercase tracking-[0.35em] text-blue-200">Partner with Brightscale</p>
+                    <h2 id="supply-chain-engage" class="text-2xl lg:text-3xl font-semibold">Need to secure every link in your software supply chain?</h2>
+                    <p class="text-slate-100/80">We map dependency risk, implement provenance controls, and guide policy rollouts so your teams can ship confidently—even under regulatory scrutiny.</p>
+                </div>
+                <div class="flex flex-col gap-3 lg:items-end">
+                    <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-blue-100/70">Schedule a Consultation</a>
+                    <a href="mailto:hello@brightscale.partners" class="text-sm font-medium text-blue-100 transition hover:text-white">hello@brightscale.partners</a>
+                </div>
+            </div>
+        </section>
 
         <section id="overview" class="mb-8 content-section">
             <h2 class="text-2xl font-bold text-gray-800 border-b-2 border-blue-500 pb-2 mb-4">Overview of Current Supply Chain Security Risks</h2>
@@ -334,10 +348,49 @@
             });
         });
     </script>
-    <footer class="bg-slate-900 text-slate-100 py-6 mt-16">
-        <div class="max-w-6xl mx-auto px-6 text-sm text-center sm:text-left sm:flex sm:items-center sm:justify-between gap-4">
-            <span>© 2024 Software Engineering Knowledge Hub. All rights reserved.</span>
-            <a href="index.html" class="text-slate-300 transition hover:text-white">Back to home ↗</a>
+    <footer class="bg-slate-950 text-slate-100 mt-16">
+        <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+            <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+                <div class="space-y-4">
+                    <div class="flex items-center gap-3">
+                        <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-blue-400/20 text-lg font-semibold text-blue-200">SE</span>
+                        <div class="text-sm">
+                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="text-slate-300">Software Advisory &amp; Transformation</p>
+                        </div>
+                    </div>
+                    <p class="text-sm leading-relaxed text-slate-400">We partner with platform, security, and FinOps leaders to tighten supply chain controls without slowing delivery.</p>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Offices</h3>
+                    <ul class="space-y-3 text-sm text-slate-300">
+                        <li><span class="font-semibold text-white">San Francisco</span> — 575 Market Street, Suite 3200</li>
+                        <li><span class="font-semibold text-white">New York</span> — 85 Broad Street, 28th Floor</li>
+                        <li><span class="font-semibold text-white">London</span> — 1 Finsbury Avenue, Level 4</li>
+                    </ul>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Connect</h3>
+                    <p class="text-sm text-slate-300">Call <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a> or email <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+                    <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-blue-100/70">Schedule a Consultation</a>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Social Proof</h3>
+                    <div class="flex flex-wrap gap-3">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">G2 High Performer</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">Cloud Verified Partner</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">ISO 27001 Ready</span>
+                    </div>
+                </div>
+            </div>
+            <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <div class="flex flex-wrap gap-6">
+                    <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
+                    <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
+                    <a href="#" class="transition hover:text-slate-200">Code of Conduct</a>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/State_of_Modern_Unit_Testing.html
+++ b/State_of_Modern_Unit_Testing.html
@@ -64,14 +64,45 @@
 </head>
 <body class="antialiased">
 
-    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div class="flex justify-end mb-6">
-            <a href="index.html" class="home-button" aria-label="Return to the home page">Home</a>
+    <header class="brand-header">
+        <div class="brand-header__bar">
+            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+                <span class="brand-header__glyph" aria-hidden="true">SE</span>
+                <span class="brand-header__lockup">
+                    <span>Software Advisory</span>
+                    <span>Brightscale Partners</span>
+                </span>
+            </a>
+            <nav class="brand-header__nav" aria-label="Primary">
+                <a class="brand-header__link" href="index.html#services">Services</a>
+                <a class="brand-header__link" href="index.html#industries">Industries</a>
+                <a class="brand-header__link" href="index.html#insights">Insights</a>
+                <a class="brand-header__link" href="index.html#about">About</a>
+                <a class="brand-header__link" href="index.html#contact">Contact</a>
+            </nav>
+            <a class="brand-header__cta" href="index.html#contact">Schedule a Consultation</a>
         </div>
+    </header>
+
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <header class="text-center mb-12">
             <h1 class="text-4xl md:text-5xl font-bold text-gray-800">The State of Modern Unit Testing</h1>
             <p class="mt-4 text-lg text-gray-600 max-w-3xl mx-auto">An interactive guide to the methods, tools, and future trends shaping software quality today.</p>
         </header>
+
+        <section aria-labelledby="unit-testing-engage" class="mb-12">
+            <div class="rounded-3xl bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 px-8 py-10 text-white shadow-xl flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                <div class="space-y-3 max-w-2xl text-left">
+                    <p class="text-sm font-semibold uppercase tracking-[0.35em] text-emerald-200">Partner with Brightscale</p>
+                    <h2 id="unit-testing-engage" class="text-2xl lg:text-3xl font-semibold">Need help scaling reliable automated testing?</h2>
+                    <p class="text-slate-100/80">We coach teams on quality strategy, implement tooling, and connect test metrics to executive scorecards for lasting impact.</p>
+                </div>
+                <div class="flex flex-col gap-3 lg:items-end">
+                    <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-emerald-100/70">Schedule a Consultation</a>
+                    <a href="mailto:hello@brightscale.partners" class="text-sm font-medium text-emerald-100 transition hover:text-white">hello@brightscale.partners</a>
+                </div>
+            </div>
+        </section>
 
         <nav class="flex justify-center border-b border-gray-200 mb-12 flex-wrap">
             <button data-target="overview" class="nav-item px-4 py-3 text-sm md:text-base font-medium text-gray-500 hover:text-gray-700 active">Overview</button>
@@ -391,10 +422,49 @@
             renderTools();
         });
     </script>
-    <footer class="bg-slate-900 text-slate-100 py-6 mt-16">
-        <div class="max-w-6xl mx-auto px-6 text-sm text-center sm:text-left sm:flex sm:items-center sm:justify-between gap-4">
-            <span>© 2024 Software Engineering Knowledge Hub. All rights reserved.</span>
-            <a href="index.html" class="text-slate-300 transition hover:text-white">Back to home ↗</a>
+    <footer class="bg-slate-950 text-slate-100 mt-16">
+        <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+            <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+                <div class="space-y-4">
+                    <div class="flex items-center gap-3">
+                        <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-emerald-400/20 text-lg font-semibold text-emerald-200">SE</span>
+                        <div class="text-sm">
+                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="text-slate-300">Software Advisory &amp; Transformation</p>
+                        </div>
+                    </div>
+                    <p class="text-sm leading-relaxed text-slate-400">We strengthen quality practices, testing automation, and engineering culture for teams shipping mission-critical software.</p>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Offices</h3>
+                    <ul class="space-y-3 text-sm text-slate-300">
+                        <li><span class="font-semibold text-white">San Francisco</span> — 575 Market Street, Suite 3200</li>
+                        <li><span class="font-semibold text-white">New York</span> — 85 Broad Street, 28th Floor</li>
+                        <li><span class="font-semibold text-white">London</span> — 1 Finsbury Avenue, Level 4</li>
+                    </ul>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Connect</h3>
+                    <p class="text-sm text-slate-300">Call <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a> or email <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+                    <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-emerald-100/70">Schedule a Consultation</a>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Social Proof</h3>
+                    <div class="flex flex-wrap gap-3">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">G2 High Performer</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">Cloud Verified Partner</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">ISO 27001 Ready</span>
+                    </div>
+                </div>
+            </div>
+            <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <div class="flex flex-wrap gap-6">
+                    <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
+                    <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
+                    <a href="#" class="transition hover:text-slate-200">Code of Conduct</a>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/Top_Challenges_in_Software_Engineering.html
+++ b/Top_Challenges_in_Software_Engineering.html
@@ -82,11 +82,11 @@
             <nav class="brand-header__nav" aria-label="Primary">
                 <a class="brand-header__link" href="index.html#services">Services</a>
                 <a class="brand-header__link" href="index.html#industries">Industries</a>
-                <a class="brand-header__link" href="index.html#explore">Insights</a>
+                <a class="brand-header__link" href="index.html#insights">Insights</a>
                 <a class="brand-header__link" href="index.html#about">About</a>
                 <a class="brand-header__link" href="index.html#contact">Contact</a>
             </nav>
-            <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+            <a class="brand-header__cta" href="index.html#contact">Schedule a Consultation</a>
         </div>
     </header>
 
@@ -141,7 +141,21 @@
                 </div>
             </div>
         </section>
-        
+
+        <section aria-labelledby="challenges-engage" class="mb-16">
+            <div class="rounded-3xl bg-gradient-to-r from-slate-900 via-slate-800 to-slate-900 px-8 py-10 text-white shadow-xl flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                <div class="space-y-3 max-w-2xl text-left">
+                    <p class="text-sm font-semibold uppercase tracking-[0.35em] text-emerald-200">Partner with Brightscale</p>
+                    <h2 id="challenges-engage" class="text-2xl lg:text-3xl font-semibold">Prioritizing these challenges? Bring in experienced transformation guides.</h2>
+                    <p class="text-slate-100/80">We help engineering executives align roadmaps, modernize platforms, and upskill teams—translating complex challenges into measurable wins.</p>
+                </div>
+                <div class="flex flex-col gap-3 lg:items-end">
+                    <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-emerald-100/70">Schedule a Consultation</a>
+                    <a href="mailto:hello@brightscale.partners" class="text-sm font-medium text-emerald-100 transition hover:text-white">hello@brightscale.partners</a>
+                </div>
+            </div>
+        </section>
+
         <div id="challenge-details-container" class="my-12">
             <!-- Dynamic content will be injected here -->
         </div>
@@ -645,10 +659,49 @@
             });
         });
     </script>
-    <footer class="bg-slate-900 text-slate-100 py-6 mt-16">
-        <div class="max-w-6xl mx-auto px-6 text-sm text-center sm:text-left sm:flex sm:items-center sm:justify-between gap-4">
-            <span>© 2024 Software Engineering Knowledge Hub. All rights reserved.</span>
-            <a href="index.html" class="text-slate-300 transition hover:text-white">Back to home ↗</a>
+    <footer class="bg-slate-950 text-slate-100 mt-16">
+        <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+            <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+                <div class="space-y-4">
+                    <div class="flex items-center gap-3">
+                        <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-emerald-400/20 text-lg font-semibold text-emerald-200">SE</span>
+                        <div class="text-sm">
+                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="text-slate-300">Software Advisory &amp; Transformation</p>
+                        </div>
+                    </div>
+                    <p class="text-sm leading-relaxed text-slate-400">We orchestrate strategy, product, and people change so engineering organizations can scale with confidence.</p>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Offices</h3>
+                    <ul class="space-y-3 text-sm text-slate-300">
+                        <li><span class="font-semibold text-white">San Francisco</span> — 575 Market Street, Suite 3200</li>
+                        <li><span class="font-semibold text-white">New York</span> — 85 Broad Street, 28th Floor</li>
+                        <li><span class="font-semibold text-white">London</span> — 1 Finsbury Avenue, Level 4</li>
+                    </ul>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Connect</h3>
+                    <p class="text-sm text-slate-300">Call <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a> or email <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+                    <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-emerald-100/70">Schedule a Consultation</a>
+                </div>
+                <div class="space-y-4">
+                    <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Social Proof</h3>
+                    <div class="flex flex-wrap gap-3">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">G2 High Performer</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">Cloud Verified Partner</span>
+                        <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">ISO 27001 Ready</span>
+                    </div>
+                </div>
+            </div>
+            <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <div class="flex flex-wrap gap-6">
+                    <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
+                    <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
+                    <a href="#" class="transition hover:text-slate-200">Code of Conduct</a>
+                </div>
+            </div>
         </div>
     </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
             <a class="brand-header__link" href="index.html#about">About</a>
             <a class="brand-header__link" href="index.html#contact">Contact</a>
           </nav>
-          <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+          <a class="brand-header__cta" href="#contact">Schedule a Consultation</a>
         </div>
         <div class="brand-hero relative z-10 text-white">
           <p class="brand-hero__eyebrow text-sky-200">Insight Library</p>
@@ -85,6 +85,9 @@
             </a>
             <a href="#unit-testing" class="brand-hero__action-secondary">
               Discover Unit Testing Insights
+            </a>
+            <a href="#contact" class="brand-hero__action-secondary">
+              Schedule a Consultation
             </a>
           </div>
           <dl class="brand-hero__stats">
@@ -523,12 +526,106 @@
           </section>
         </div>
       </section>
+
+      <section id="contact" class="rounded-3xl bg-white/90 p-10 shadow-xl ring-1 ring-slate-200/70">
+        <div class="grid gap-10 lg:grid-cols-2 lg:items-start">
+          <div class="space-y-6">
+            <span class="inline-flex items-center gap-2 rounded-full bg-cyan-100 px-4 py-1 text-sm font-medium text-cyan-700">Partner with Brightscale</span>
+            <h2 class="text-3xl font-semibold text-slate-900">Let's build your next engineering win together</h2>
+            <p class="text-lg text-slate-600">Share a few details about your priorities and we'll connect you with the right advisory lead within one business day.</p>
+            <ul class="space-y-4 text-slate-600">
+              <li class="flex items-start gap-3"><span class="mt-1 text-lg">🧭</span><span>Design a transformation roadmap grounded in measurable OKRs and product outcomes.</span></li>
+              <li class="flex items-start gap-3"><span class="mt-1 text-lg">🤝</span><span>Co-create the engagement model—remote, hybrid, or embedded—to match your team's cadence.</span></li>
+              <li class="flex items-start gap-3"><span class="mt-1 text-lg">📊</span><span>Receive a tailored briefing covering benchmarks, risks, and a 90-day acceleration plan.</span></li>
+            </ul>
+            <div class="rounded-2xl bg-slate-900/90 p-6 text-slate-100 shadow-lg">
+              <p class="text-sm font-semibold uppercase tracking-[0.3em] text-cyan-200">Direct line</p>
+              <p class="mt-3 text-lg">Prefer to reach out now? <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a></p>
+              <p class="text-sm text-slate-300">Or email us at <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+            </div>
+          </div>
+          <form action="#" method="post" class="space-y-6 rounded-3xl bg-slate-50 p-8 shadow-inner ring-1 ring-slate-200">
+            <div>
+              <label for="contact-name" class="block text-sm font-semibold text-slate-700">Full name</label>
+              <input id="contact-name" name="name" type="text" required class="mt-2 w-full rounded-xl border border-slate-200 px-4 py-3 text-slate-900 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-400/60" placeholder="Jordan Patel" />
+            </div>
+            <div class="grid gap-6 sm:grid-cols-2">
+              <div>
+                <label for="contact-email" class="block text-sm font-semibold text-slate-700">Work email</label>
+                <input id="contact-email" name="email" type="email" required class="mt-2 w-full rounded-xl border border-slate-200 px-4 py-3 text-slate-900 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-400/60" placeholder="you@company.com" />
+              </div>
+              <div>
+                <label for="contact-company" class="block text-sm font-semibold text-slate-700">Company</label>
+                <input id="contact-company" name="company" type="text" class="mt-2 w-full rounded-xl border border-slate-200 px-4 py-3 text-slate-900 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-400/60" placeholder="Acme Corp" />
+              </div>
+            </div>
+            <div>
+              <label for="contact-focus" class="block text-sm font-semibold text-slate-700">Primary focus area</label>
+              <select id="contact-focus" name="focus" class="mt-2 w-full rounded-xl border border-slate-200 px-4 py-3 text-slate-900 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-400/60">
+                <option>Platform engineering acceleration</option>
+                <option>FinOps &amp; technology spend management</option>
+                <option>Secure-by-design &amp; software assurance</option>
+                <option>Product delivery modernization</option>
+                <option>Executive briefing or workshop</option>
+                <option>Something else</option>
+              </select>
+            </div>
+            <div>
+              <label for="contact-notes" class="block text-sm font-semibold text-slate-700">What would you like to achieve?</label>
+              <textarea id="contact-notes" name="notes" rows="4" class="mt-2 w-full rounded-xl border border-slate-200 px-4 py-3 text-slate-900 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-400/60" placeholder="Share goals, timelines, or challenges."></textarea>
+            </div>
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p class="text-xs text-slate-500">By submitting, you agree to our <a href="#" class="font-semibold text-slate-700 underline-offset-4 hover:underline">Privacy Policy</a>.</p>
+              <button type="submit" class="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-900/30 transition hover:bg-slate-700">Submit request</button>
+            </div>
+          </form>
+        </div>
+      </section>
     </div>
   </main>
-  <footer class="bg-slate-900 text-slate-100 py-6">
-    <div class="max-w-6xl mx-auto px-6 text-sm text-center sm:text-left sm:flex sm:items-center sm:justify-between gap-4">
-      <span>© 2024 Software Engineering Knowledge Hub. All rights reserved.</span>
-      <a href="#top" class="hidden text-slate-300 transition hover:text-white sm:inline-flex">Back to top ↑</a>
+  <footer class="bg-slate-950 text-slate-100">
+    <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+      <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+        <div class="space-y-4">
+          <div class="flex items-center gap-3">
+            <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-cyan-400/20 text-lg font-semibold text-cyan-200">SE</span>
+            <div class="text-sm">
+              <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+              <p class="text-slate-300">Software Advisory &amp; Transformation</p>
+            </div>
+          </div>
+          <p class="text-sm leading-relaxed text-slate-400">We partner with engineering, platform, and security leaders to turn ambitious strategies into measurable delivery outcomes.</p>
+        </div>
+        <div class="space-y-4">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Offices</h3>
+          <ul class="space-y-3 text-sm text-slate-300">
+            <li><span class="font-semibold text-white">San Francisco</span> — 575 Market Street, Suite 3200</li>
+            <li><span class="font-semibold text-white">New York</span> — 85 Broad Street, 28th Floor</li>
+            <li><span class="font-semibold text-white">London</span> — 1 Finsbury Avenue, Level 4</li>
+          </ul>
+        </div>
+        <div class="space-y-4">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Connect</h3>
+          <p class="text-sm text-slate-300">Call <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a> or email <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+          <a href="#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-slate-100">Schedule a Consultation</a>
+        </div>
+        <div class="space-y-4">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Social Proof</h3>
+          <div class="flex flex-wrap gap-3">
+            <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">G2 High Performer</span>
+            <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">Cloud Verified Partner</span>
+            <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">ISO 27001 Ready</span>
+          </div>
+        </div>
+      </div>
+      <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+        <p>© 2024 Brightscale Partners. All rights reserved.</p>
+        <div class="flex flex-wrap gap-6">
+          <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
+          <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
+          <a href="#" class="transition hover:text-slate-200">Code of Conduct</a>
+        </div>
+      </div>
     </div>
   </footer>
 

--- a/platform-engineering-executive-report.html
+++ b/platform-engineering-executive-report.html
@@ -82,6 +82,96 @@
     box-shadow: 0 0 40px var(--shadow);
   }
 
+  .engage-block {
+    margin: 2.5rem 0;
+  }
+
+  .cta-panel {
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(14, 116, 144, 0.9));
+    border-radius: 24px;
+    padding: 2.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+    box-shadow: 0 24px 60px -28px rgba(8, 47, 73, 0.6);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+  }
+
+  .cta-copy {
+    max-width: 34rem;
+  }
+
+  .cta-copy .eyebrow {
+    font-size: 0.7rem;
+    letter-spacing: 0.4em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: rgba(125, 211, 252, 0.85);
+    margin-bottom: 1rem;
+  }
+
+  .cta-copy h2 {
+    font-size: clamp(1.5rem, 2vw, 2.25rem);
+    margin-bottom: 1rem;
+    color: var(--text);
+  }
+
+  .cta-copy p {
+    color: rgba(226, 232, 240, 0.85);
+    line-height: 1.6;
+  }
+
+  .cta-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .cta-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    padding: 0.85rem 1.9rem;
+    font-weight: 600;
+    background: #ffffff;
+    color: #0f172a;
+    text-decoration: none;
+    box-shadow: 0 20px 32px -20px rgba(15, 23, 42, 0.8);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  }
+
+  .cta-button:hover,
+  .cta-button:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 26px 40px -20px rgba(15, 23, 42, 0.85);
+    background: rgba(255, 255, 255, 0.9);
+  }
+
+  .cta-link {
+    color: rgba(226, 232, 240, 0.75);
+    font-size: 0.9rem;
+    text-decoration: none;
+  }
+
+  .cta-link:hover,
+  .cta-link:focus-visible {
+    color: var(--text);
+    text-decoration: underline;
+  }
+
+  @media (min-width: 768px) {
+    .cta-panel {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .cta-actions {
+      align-items: flex-end;
+    }
+  }
+
   .brand {
     padding: 20px 18px 12px 18px;
     border-bottom: 1px solid var(--border);
@@ -291,11 +381,11 @@
       <nav class="brand-header__nav" aria-label="Primary">
         <a class="brand-header__link" href="index.html#services">Services</a>
         <a class="brand-header__link" href="index.html#industries">Industries</a>
-        <a class="brand-header__link" href="index.html#explore">Insights</a>
+        <a class="brand-header__link" href="index.html#insights">Insights</a>
         <a class="brand-header__link" href="index.html#about">About</a>
         <a class="brand-header__link" href="index.html#contact">Contact</a>
       </nav>
-      <a class="brand-header__cta" href="mailto:hello@brightscale.partners">Talk to an Expert</a>
+      <a class="brand-header__cta" href="index.html#contact">Schedule a Consultation</a>
     </div>
   </header>
   <div class="app">
@@ -322,6 +412,20 @@
         </div>
         <div style="color:var(--muted); font-size:14px;">Prepared for leadership decisions in 2025–2026</div>
       </header>
+
+      <section aria-labelledby="exec-engage" class="engage-block">
+        <div class="cta-panel">
+          <div class="cta-copy">
+            <p class="eyebrow">Partner with Brightscale</p>
+            <h2 id="exec-engage">Take the guesswork out of platform transformation</h2>
+            <p>We coach executives, product, and platform leaders through roadmapping, business casing, and launch-readiness so your developer experience investments pay off.</p>
+          </div>
+          <div class="cta-actions">
+            <a href="index.html#contact" class="cta-button">Schedule a Consultation</a>
+            <a href="mailto:hello@brightscale.partners" class="cta-link">hello@brightscale.partners</a>
+          </div>
+        </div>
+      </section>
 
       <section id="exec-summary">
         <h2>Executive Summary</h2>
@@ -601,11 +705,50 @@
       });
     });
   </script>
-  <footer class="bg-slate-900 text-slate-100 py-6 mt-16">
-    <div class="max-w-6xl mx-auto px-6 text-sm text-center sm:text-left sm:flex sm:items-center sm:justify-between gap-4">
-      <span>© 2024 Software Engineering Knowledge Hub. All rights reserved.</span>
-      <a href="index.html" class="text-slate-300 transition hover:text-white">Back to home ↗</a>
+<footer class="bg-slate-950 text-slate-100 mt-16">
+  <div class="max-w-6xl mx-auto px-6 py-12 space-y-10">
+    <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+      <div class="space-y-4">
+        <div class="flex items-center gap-3">
+          <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-sky-400/20 text-lg font-semibold text-sky-200">SE</span>
+          <div class="text-sm">
+            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+            <p class="text-slate-300">Software Advisory &amp; Transformation</p>
+          </div>
+        </div>
+        <p class="text-sm leading-relaxed text-slate-400">From executive briefings to embedded squads, we help organizations modernize platforms, security, and delivery.</p>
+      </div>
+      <div class="space-y-4">
+        <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Offices</h3>
+        <ul class="space-y-3 text-sm text-slate-300">
+          <li><span class="font-semibold text-white">San Francisco</span> — 575 Market Street, Suite 3200</li>
+          <li><span class="font-semibold text-white">New York</span> — 85 Broad Street, 28th Floor</li>
+          <li><span class="font-semibold text-white">London</span> — 1 Finsbury Avenue, Level 4</li>
+        </ul>
+      </div>
+      <div class="space-y-4">
+        <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Connect</h3>
+        <p class="text-sm text-slate-300">Call <a href="tel:+14155550137" class="font-semibold text-white underline-offset-4 hover:underline">+1 (415) 555-0137</a> or email <a href="mailto:hello@brightscale.partners" class="font-semibold text-white underline-offset-4 hover:underline">hello@brightscale.partners</a>.</p>
+        <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-sky-100/70">Schedule a Consultation</a>
+      </div>
+      <div class="space-y-4">
+        <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">Social Proof</h3>
+        <div class="flex flex-wrap gap-3">
+          <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">G2 High Performer</span>
+          <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">Cloud Verified Partner</span>
+          <span class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200">ISO 27001 Ready</span>
+        </div>
+      </div>
     </div>
-  </footer>
+    <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+      <p>© 2024 Brightscale Partners. All rights reserved.</p>
+      <div class="flex flex-wrap gap-6">
+        <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
+        <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
+        <a href="#" class="transition hover:text-slate-200">Code of Conduct</a>
+      </div>
+    </div>
+  </div>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a consultation call-to-action to the home hero and introduce a full contact form section anchored from navigation
- update every report page with a persistent schedule-consultation nav button, inline engagement module, and refreshed multi-column footer
- extend the unit testing microsite with the global brand header and align all navigation links with the updated site structure

## Testing
- no automated tests were run (HTML/CSS content changes)


------
https://chatgpt.com/codex/tasks/task_e_68ccfc74a4188325af0753178e266aa5