### PR TITLE
Restore standalone unit testing experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,33 +18,6 @@
       --nav-link-accent: #38A89D;
       --nav-item-active-color: #0f172a;
     }
-    .content-section {
-      display: none;
-    }
-    .content-section.active {
-      display: block;
-    }
-    .chart-container {
-      position: relative;
-      width: 100%;
-      max-width: 420px;
-      margin-left: auto;
-      margin-right: auto;
-      height: 300px;
-      max-height: 420px;
-    }
-    @media (min-width: 768px) {
-      .chart-container {
-        height: 350px;
-      }
-    }
-    .tool-card, .practice-card {
-      transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-    }
-    .tool-card:hover, .practice-card:hover {
-      transform: translateY(-5px);
-      box-shadow: 0 10px 15px -3px rgba(15, 23, 42, 0.1), 0 4px 6px -2px rgba(15, 23, 42, 0.05);
-    }
   </style>
 </head>
 <body id="top" class="min-h-screen flex flex-col">
@@ -83,8 +56,8 @@
             <a href="#insights" class="brand-hero__action-primary">
               Explore Reports
             </a>
-            <a href="#unit-testing" class="brand-hero__action-secondary">
-              Discover Unit Testing Insights
+            <a href="State_of_Modern_Unit_Testing.html" class="brand-hero__action-secondary">
+              Explore the Unit Testing Deep Dive
             </a>
             <a href="#contact" class="brand-hero__action-secondary">
               Schedule a Consultation
@@ -378,6 +351,16 @@
             </ul>
           </article>
           <article class="group relative overflow-hidden rounded-3xl bg-white p-8 shadow-sm ring-1 ring-slate-200/60 transition-all hover:-translate-y-1 hover:shadow-2xl">
+            <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-teal-600 text-xl text-white shadow-lg">🧪</div>
+            <h3 class="mt-6 text-xl font-semibold text-slate-900">Unit Testing</h3>
+            <p class="mt-3 text-sm text-slate-600">
+              Explore the tools, metrics, and practices powering high-confidence releases.
+            </p>
+            <ul class="mt-5 space-y-2 text-sm">
+              <li><a href="State_of_Modern_Unit_Testing.html" class="inline-flex items-center gap-1 text-sky-600 transition hover:text-sky-800">The State of Modern Unit Testing — Interactive Deep Dive<span aria-hidden="true">→</span></a></li>
+            </ul>
+          </article>
+          <article class="group relative overflow-hidden rounded-3xl bg-white p-8 shadow-sm ring-1 ring-slate-200/60 transition-all hover:-translate-y-1 hover:shadow-2xl">
             <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-sky-600 text-xl text-white shadow-lg">🛠️</div>
             <h3 class="mt-6 text-xl font-semibold text-slate-900">Platform Engineering</h3>
             <p class="mt-3 text-sm text-slate-600">
@@ -429,171 +412,6 @@
               <li><a href="Top_Challenges_in_Software_Engineering.html" class="inline-flex items-center gap-1 text-sky-600 transition hover:text-sky-800">Top Challenges in Software Engineering<span aria-hidden="true">→</span></a></li>
             </ul>
           </article>
-        </div>
-      </section>
-
-      <section id="unit-testing" class="rounded-3xl bg-white p-6 shadow-xl ring-1 ring-slate-200/70 sm:p-10">
-        <header class="text-center mb-12">
-          <p class="text-sm font-semibold uppercase tracking-[0.4em] text-slate-400">Interactive Deep Dive</p>
-          <h2 class="mt-4 text-3xl md:text-4xl font-bold text-slate-900">The State of Modern Unit Testing</h2>
-          <p class="mt-4 text-slate-600 max-w-3xl mx-auto">
-            Explore methodologies, tools, and trends reshaping automated quality practices.
-          </p>
-        </header>
-        <nav class="flex justify-center border-b border-gray-200 mb-12 flex-wrap">
-          <button data-target="overview" class="nav-item px-4 py-3 text-sm md:text-base font-medium text-gray-500 hover:text-gray-800 active">Overview</button>
-          <button data-target="practices" class="nav-item px-4 py-3 text-sm md:text-base font-medium text-gray-500 hover:text-gray-800">Core Practices</button>
-          <button data-target="toolbox" class="nav-item px-4 py-3 text-sm md:text-base font-medium text-gray-500 hover:text-gray-800">The Toolbox</button>
-          <button data-target="future" class="nav-item px-4 py-3 text-sm md:text-base font-medium text-gray-500 hover:text-gray-800">Future Forward</button>
-          <button data-target="metrics" class="nav-item px-4 py-3 text-sm md:text-base font-medium text-gray-500 hover:text-gray-800">Key Metrics</button>
-        </nav>
-        <div>
-          <section id="overview" class="content-section active">
-            <div class="text-center mb-12">
-              <h3 class="text-3xl font-semibold text-gray-800 mb-4">The Big Picture</h3>
-              <p class="max-w-2xl mx-auto text-gray-600">
-                Unit testing is now a cornerstone of software engineering, enabling teams to ship resilient code with confidence.
-                Explore adoption stats and the outcomes they unlock.
-              </p>
-            </div>
-            <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 items-center">
-              <div class="lg:col-span-1">
-                <div class="bg-slate-50 rounded-2xl p-6 shadow-md border border-slate-100">
-                  <h4 class="font-bold text-lg text-center mb-4 text-slate-800">Project Adoption Rate</h4>
-                  <div class="chart-container">
-                    <canvas id="adoptionChart"></canvas>
-                  </div>
-                </div>
-              </div>
-              <div class="lg:col-span-2 grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div class="bg-slate-50 p-6 rounded-2xl shadow-md border border-slate-100">
-                  <h4 class="font-bold text-lg text-gray-800">🚀 Faster Debugging</h4>
-                  <p class="text-gray-600 mt-2">Pinpoint defects in minutes rather than hours and keep delivery velocity high.</p>
-                </div>
-                <div class="bg-slate-50 p-6 rounded-2xl shadow-md border border-slate-100">
-                  <h4 class="font-bold text-lg text-gray-800">🛡️ Increased Resilience</h4>
-                  <p class="text-gray-600 mt-2">A comprehensive safety net enables fearless refactoring and rapid iteration.</p>
-                </div>
-                <div class="bg-slate-50 p-6 rounded-2xl shadow-md border border-slate-100">
-                  <h4 class="font-bold text-lg text-gray-800">📚 Living Documentation</h4>
-                  <p class="text-gray-600 mt-2">Executable tests become a canonical reference for how systems should behave.</p>
-                </div>
-                <div class="bg-slate-50 p-6 rounded-2xl shadow-md border border-slate-100">
-                  <h4 class="font-bold text-lg text-gray-800">💰 Lower Costs</h4>
-                  <p class="text-gray-600 mt-2">Catching defects early avoids expensive production issues and emergency fixes.</p>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section id="practices" class="content-section">
-            <div class="text-center mb-12">
-              <h3 class="text-3xl font-semibold text-gray-800 mb-4">Core Practices &amp; Methodologies</h3>
-              <p class="max-w-2xl mx-auto text-gray-600">
-                Move beyond the basics with progressive strategies that keep your suite lean, expressive, and high-value. Tap a
-                card to explore each technique.
-              </p>
-            </div>
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-              <div class="practice-card cursor-pointer bg-slate-50 p-6 rounded-2xl shadow-md border border-slate-100" data-practice="tdd">
-                <h4 class="font-bold text-xl text-gray-800">TDD</h4>
-                <p class="text-gray-600 mt-2">Write the test before the code and refactor with confidence.</p>
-              </div>
-              <div class="practice-card cursor-pointer bg-slate-50 p-6 rounded-2xl shadow-md border border-slate-100" data-practice="bdd">
-                <h4 class="font-bold text-xl text-gray-800">BDD</h4>
-                <p class="text-gray-600 mt-2">Collaborate around human-readable scenarios that drive development.</p>
-              </div>
-              <div class="practice-card cursor-pointer bg-slate-50 p-6 rounded-2xl shadow-md border border-slate-100" data-practice="property">
-                <h4 class="font-bold text-xl text-gray-800">Property-Based</h4>
-                <p class="text-gray-600 mt-2">Generate diverse inputs automatically to surface hidden edge cases.</p>
-              </div>
-              <div class="practice-card cursor-pointer bg-slate-50 p-6 rounded-2xl shadow-md border border-slate-100" data-practice="mutation">
-                <h4 class="font-bold text-xl text-gray-800">Mutation Testing</h4>
-                <p class="text-gray-600 mt-2">Test the quality of your tests by injecting intentional defects.</p>
-              </div>
-            </div>
-            <div id="practice-details" class="mt-12"></div>
-          </section>
-
-          <section id="toolbox" class="content-section">
-            <div class="text-center mb-12">
-              <h3 class="text-3xl font-semibold text-gray-800 mb-4">The Modern Testing Toolbox</h3>
-              <p class="max-w-2xl mx-auto text-gray-600">
-                Filter frameworks, libraries, and utilities across ecosystems to assemble your perfect stack.
-              </p>
-            </div>
-            <div class="flex justify-center space-x-2 md:space-x-4 mb-8 flex-wrap gap-2">
-              <button class="tool-filter-btn bg-slate-200 text-gray-800 px-4 py-2 rounded-full font-medium active" data-lang="all">All</button>
-              <button class="tool-filter-btn bg-slate-200 text-gray-800 px-4 py-2 rounded-full font-medium" data-lang="javascript">JavaScript</button>
-              <button class="tool-filter-btn bg-slate-200 text-gray-800 px-4 py-2 rounded-full font-medium" data-lang="python">Python</button>
-              <button class="tool-filter-btn bg-slate-200 text-gray-800 px-4 py-2 rounded-full font-medium" data-lang="java">Java</button>
-              <button class="tool-filter-btn bg-slate-200 text-gray-800 px-4 py-2 rounded-full font-medium" data-lang="dotnet">.NET</button>
-            </div>
-            <div id="tool-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"></div>
-          </section>
-
-          <section id="future" class="content-section">
-            <div class="text-center mb-12">
-              <h3 class="text-3xl font-semibold text-gray-800 mb-4">Future Forward: Trends in Testing</h3>
-              <p class="max-w-2xl mx-auto text-gray-600">
-                Stay ahead of the curve with the innovations reshaping how we validate and ship software.
-              </p>
-            </div>
-            <div class="space-y-12">
-              <div>
-                <h4 class="text-2xl font-semibold text-gray-800">🤖 AI-Powered Testing</h4>
-                <p class="mt-4 text-gray-600 leading-relaxed">
-                  AI systems increasingly draft tests, reveal blind spots, and self-heal flaky suites—helping teams focus on
-                  designing great experiences instead of plumbing.
-                </p>
-              </div>
-              <div>
-                <h4 class="text-2xl font-semibold text-gray-800">🧩 Testing Microservices &amp; Serverless</h4>
-                <p class="mt-4 text-gray-600 leading-relaxed">
-                  Distributed architectures demand sophisticated mocking, contract testing, and service virtualization to isolate
-                  behaviour and ensure components remain dependable.
-                </p>
-              </div>
-              <div>
-                <h4 class="text-2xl font-semibold text-gray-800">⬅️ The "Shift Left" Movement</h4>
-                <p class="mt-4 text-gray-600 leading-relaxed">
-                  Embedding testing from the first commit keeps regressions out of mainline branches and empowers developers to
-                  own quality as they ship.
-                </p>
-              </div>
-            </div>
-          </section>
-
-          <section id="metrics" class="content-section">
-            <div class="text-center mb-12">
-              <h3 class="text-3xl font-semibold text-gray-800 mb-4">Measuring What Matters</h3>
-              <p class="max-w-2xl mx-auto text-gray-600">
-                Coverage alone isn’t the goal. Use this interactive simulator to connect numeric targets to real-world confidence
-                levels.
-              </p>
-            </div>
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-              <div class="bg-slate-50 p-6 rounded-2xl shadow-md border border-slate-100">
-                <h4 class="font-bold text-lg text-center mb-4">Interactive Coverage Simulator</h4>
-                <div class="chart-container" style="max-width: 600px;">
-                  <canvas id="coverageChart"></canvas>
-                </div>
-              </div>
-              <div class="space-y-6">
-                <div>
-                  <label for="coverage-slider" class="block font-medium text-gray-700">
-                    Adjust Target Coverage:
-                    <span id="coverage-value" class="font-bold text-[#38A89D]">75%</span>
-                  </label>
-                  <input id="coverage-slider" type="range" min="0" max="100" value="75" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer">
-                </div>
-                <div id="coverage-explanation" class="bg-gray-50 p-6 rounded-lg border border-gray-200">
-                  <h5 class="font-bold text-gray-800">Coverage Interpretation</h5>
-                  <p class="mt-2 text-gray-600"></p>
-                </div>
-              </div>
-            </div>
-          </section>
         </div>
       </section>
 
@@ -699,189 +517,5 @@
     </div>
   </footer>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const navItems = document.querySelectorAll('.nav-item');
-      const contentSections = document.querySelectorAll('.content-section');
-
-      const practiceDetailsContainer = document.getElementById('practice-details');
-      const practiceCards = document.querySelectorAll('.practice-card');
-
-      const toolFilterBtns = document.querySelectorAll('.tool-filter-btn');
-      const toolGrid = document.getElementById('tool-grid');
-
-      const practicesData = {
-        tdd: {
-          title: 'Test-Driven Development (TDD)',
-          description: 'TDD follows a short, repetitive "Red-Green-Refactor" cycle. First, you write a failing test for a new feature (Red). Then, you write the minimal amount of code required to make the test pass (Green). Finally, you clean up the code while ensuring the test still passes (Refactor). This ensures that all code is written with a specific requirement in mind and is testable by design.',
-          benefits: ['Guarantees test coverage', 'Improves code design', 'Reduces bugs']
-        },
-        bdd: {
-          title: 'Behavior-Driven Development (BDD)',
-          description: 'BDD extends TDD by writing tests in a natural, human-readable language. It uses a "Given-When-Then" format to describe a feature\'s behavior from the user\'s perspective. This improves communication between developers, QA, and business stakeholders, ensuring that the software meets business requirements.',
-          benefits: ['Aligns development with business goals', 'Creates living documentation', 'Encourages collaboration']
-        },
-        property: {
-          title: 'Property-Based Testing',
-          description: 'Instead of writing tests for specific example inputs, property-based testing involves defining general properties that your code should hold true for any valid input. The testing framework then generates hundreds of random inputs to try and falsify these properties. This is excellent for finding edge cases that developers might not think of.',
-          benefits: ['Finds subtle edge-case bugs', 'Tests a wider range of inputs', 'Forces clearer thinking about code invariants']
-        },
-        mutation: {
-          title: 'Mutation Testing',
-          description: 'Mutation testing evaluates the quality of your existing tests. It works by making small, deliberate changes (mutations) to your source code, such as changing a `+` to a `-`. It then runs your test suite. If a test fails, the "mutant" is considered "killed." If all tests pass, the mutant "survives," indicating a potential gap in your test coverage that you should address.',
-          benefits: ['Measures test suite effectiveness', 'Identifies weak or trivial tests', 'Drives higher-quality test writing']
-        }
-      };
-
-      const toolsData = [
-        { name: 'Jest', lang: 'javascript', type: 'Framework', desc: 'A delightful JavaScript Testing Framework with a focus on simplicity.' },
-        { name: 'Mocha', lang: 'javascript', type: 'Framework', desc: 'A feature-rich JavaScript test framework running on Node.js and in the browser.' },
-        { name: 'Chai', lang: 'javascript', type: 'Assertion Library', desc: 'A BDD / TDD assertion library for node and the browser that can be delightfully paired with any javascript testing framework.' },
-        { name: 'PyTest', lang: 'python', type: 'Framework', desc: 'A mature full-featured Python testing tool that helps you write better programs.' },
-        { name: 'unittest', lang: 'python', type: 'Framework', desc: 'Python\'s built-in "batteries-included" unit testing framework.' },
-        { name: 'JUnit 5', lang: 'java', type: 'Framework', desc: 'The most widely used testing framework for the Java programming language.' },
-        { name: 'Mockito', lang: 'java', type: 'Mocking Library', desc: 'A popular mocking framework for Java which allows you to write beautiful tests with a clean & simple API.' },
-        { name: 'xUnit.net', lang: 'dotnet', type: 'Framework', desc: 'A free, open source, community-focused unit testing tool for the .NET Framework.' },
-        { name: 'NUnit', lang: 'dotnet', type: 'Framework', desc: 'An open-source unit-testing framework for all .Net languages.' },
-        { name: 'Moq', lang: 'dotnet', type: 'Mocking Library', desc: 'The most popular and friendly mocking framework for .NET.' }
-      ];
-
-      function switchTab(targetId) {
-        navItems.forEach(item => {
-          item.classList.toggle('active', item.dataset.target === targetId);
-        });
-        contentSections.forEach(section => {
-          section.classList.toggle('active', section.id === targetId);
-        });
-      }
-
-      navItems.forEach(item => {
-        item.addEventListener('click', () => {
-          switchTab(item.dataset.target);
-        });
-      });
-
-      function showPracticeDetails(practiceKey) {
-        const data = practicesData[practiceKey];
-        if (!data) return;
-
-        const benefitsHtml = data.benefits.map(b => `<li class="flex items-start"><span class="text-[#38A89D] mr-2 mt-1">✔</span>${b}</li>`).join('');
-
-        practiceDetailsContainer.innerHTML = `
-          <div class="bg-white p-8 rounded-2xl shadow-lg border border-gray-200 animate-fade-in">
-            <h5 class="text-2xl font-bold text-gray-800">${data.title}</h5>
-            <p class="mt-4 text-gray-600 leading-relaxed">${data.description}</p>
-            <h6 class="mt-6 font-semibold text-gray-700">Key Benefits:</h6>
-            <ul class="mt-2 space-y-2 text-gray-600">${benefitsHtml}</ul>
-          </div>
-        `;
-      }
-
-      practiceCards.forEach(card => {
-        card.addEventListener('click', () => {
-          practiceCards.forEach(c => c.classList.remove('ring-2', 'ring-[#38A89D]'));
-          card.classList.add('ring-2', 'ring-[#38A89D]');
-          showPracticeDetails(card.dataset.practice);
-        });
-      });
-
-      function renderTools(filterLang = 'all') {
-        toolGrid.innerHTML = '';
-        const filteredTools = filterLang === 'all' ? toolsData : toolsData.filter(tool => tool.lang === filterLang);
-
-        filteredTools.forEach(tool => {
-          const card = document.createElement('div');
-          card.className = 'tool-card bg-slate-50 p-6 rounded-2xl shadow-md border border-slate-100';
-          card.innerHTML = `
-            <h5 class="font-bold text-xl text-gray-800">${tool.name}</h5>
-            <p class="text-sm font-medium text-[#38A89D] mt-1">${tool.type}</p>
-            <p class="text-gray-600 mt-2">${tool.desc}</p>
-          `;
-          toolGrid.appendChild(card);
-        });
-      }
-
-      toolFilterBtns.forEach(btn => {
-        btn.addEventListener('click', () => {
-          toolFilterBtns.forEach(b => b.classList.remove('active', 'bg-[#38A89D]', 'text-white'));
-          btn.classList.add('active', 'bg-[#38A89D]', 'text-white');
-          renderTools(btn.dataset.lang);
-        });
-      });
-
-      const adoptionCtx = document.getElementById('adoptionChart').getContext('2d');
-      new Chart(adoptionCtx, {
-        type: 'doughnut',
-        data: {
-          labels: ['Active Projects', 'Legacy (No Tests)'],
-          datasets: [{
-            data: [85, 15],
-            backgroundColor: ['#38A89D', '#E0E7FF'],
-            borderColor: ['#FFFFFF'],
-            borderWidth: 4
-          }]
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          cutout: '70%',
-          plugins: {
-            legend: { position: 'bottom' },
-            tooltip: {
-              callbacks: {
-                label: function(context) {
-                  return `${context.label}: ${context.raw}%`;
-                }
-              }
-            }
-          }
-        }
-      });
-
-      const coverageCtx = document.getElementById('coverageChart').getContext('2d');
-      const coverageChart = new Chart(coverageCtx, {
-        type: 'bar',
-        data: {
-          labels: ['Line', 'Branch', 'Statement'],
-          datasets: [{
-            label: 'Code Coverage',
-            data: [75, 60, 72],
-            backgroundColor: ['#6EE7B7', '#38A89D', '#10B981'],
-          }]
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          scales: { y: { beginAtZero: true, max: 100 } },
-          plugins: { legend: { display: false } }
-        }
-      });
-
-      const slider = document.getElementById('coverage-slider');
-      const coverageValue = document.getElementById('coverage-value');
-      const explanationText = document.querySelector('#coverage-explanation p');
-
-      function updateCoverage(value) {
-        coverageValue.textContent = `${value}%`;
-        coverageChart.data.datasets[0].data = [value, Math.max(0, value - 15), Math.max(0, value - 3)];
-        coverageChart.update();
-
-        if (value < 40) {
-          explanationText.textContent = 'At this level, testing is minimal. There are significant gaps, and the codebase is likely unstable and prone to bugs. Confidence in making changes is very low.';
-        } else if (value < 70) {
-          explanationText.textContent = 'This indicates a foundational level of testing. The most critical paths are likely covered, but many edge cases and error conditions are probably missed. It\'s a good start, but there is a moderate risk.';
-        } else if (value < 90) {
-          explanationText.textContent = 'This is a strong level of coverage, typical for mature and healthy projects. Most business logic is well-tested, providing high confidence for refactoring and adding features. The risk of regression is low.';
-        } else {
-          explanationText.textContent = 'Excellent coverage. This implies a very rigorous testing culture. While 100% can be impractical, being in this range means the code is exceptionally robust and well-documented by its tests. Diminishing returns may apply.';
-        }
-      }
-
-      slider.addEventListener('input', (e) => updateCoverage(e.target.value));
-
-      updateCoverage(75);
-      renderTools();
-    });
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restore the interactive State of Modern Unit Testing standalone page
- streamline the homepage by replacing the embedded deep dive section with a concise insights card that links to the dedicated report
- update the hero call to action to route visitors directly to the standalone experience

## Testing
- not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68cd30d6a8848325aeb1d8d7cfdfbcc0