### PR TITLE
Centralize firm name rendering

### DIFF
--- a/Design_Thinking_in_SDLC.html
+++ b/Design_Thinking_in_SDLC.html
@@ -113,11 +113,11 @@
 <body class="smooth-scroll">
   <header class="brand-header">
     <div class="brand-header__bar">
-      <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+      <a href="index.html" class="brand-header__identity" data-firm-name-aria-label="{firm} home">
         <span class="brand-header__glyph" aria-hidden="true">SE</span>
         <span class="brand-header__lockup">
           <span>Software Advisory</span>
-          <span>Brightscale Partners</span>
+          <span data-firm-name></span>
         </span>
       </a>
       <nav class="brand-header__nav" aria-label="Primary">
@@ -336,7 +336,7 @@
           <div class="flex items-center gap-3">
             <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-cyan-400/20 text-lg font-semibold text-cyan-200">SE</span>
             <div class="text-sm">
-              <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+              <p class="font-semibold tracking-[0.3em] text-slate-400"><span data-firm-name></span></p>
               <p class="text-slate-300">Software Advisory &amp; Transformation</p>
             </div>
           </div>
@@ -365,7 +365,7 @@
         </div>
       </div>
       <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
-        <p>© 2024 Brightscale Partners. All rights reserved.</p>
+        <p>© 2024 <span data-firm-name></span>. All rights reserved.</p>
         <div class="flex flex-wrap gap-6">
           <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
           <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
@@ -374,5 +374,6 @@
       </div>
     </div>
   </footer>
+  <script type="module" src="scripts/branding/apply-firm-name.js"></script>
 </body>
 </html>

--- a/FinOps_Detailed.html
+++ b/FinOps_Detailed.html
@@ -108,11 +108,11 @@
 
     <header class="brand-header">
         <div class="brand-header__bar">
-            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+            <a href="index.html" class="brand-header__identity" data-firm-name-aria-label="{firm} home">
                 <span class="brand-header__glyph" aria-hidden="true">SE</span>
                 <span class="brand-header__lockup">
                     <span>Software Advisory</span>
-                    <span>Brightscale Partners</span>
+                    <span data-firm-name></span>
                 </span>
             </a>
             <nav class="brand-header__nav" aria-label="Primary">
@@ -466,7 +466,7 @@
                     <div class="flex items-center gap-3">
                         <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-blue-400/20 text-lg font-semibold text-blue-200">SE</span>
                         <div class="text-sm">
-                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="font-semibold tracking-[0.3em] text-slate-400"><span data-firm-name></span></p>
                             <p class="text-slate-300">Software Advisory &amp; Transformation</p>
                         </div>
                     </div>
@@ -495,7 +495,7 @@
                 </div>
             </div>
             <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
-                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <p>© 2024 <span data-firm-name></span>. All rights reserved.</p>
                 <div class="flex flex-wrap gap-6">
                     <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
                     <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
@@ -504,5 +504,6 @@
             </div>
         </div>
     </footer>
+  <script type="module" src="scripts/branding/apply-firm-name.js"></script>
 </body>
 </html>

--- a/FinOps_Summary.html
+++ b/FinOps_Summary.html
@@ -34,11 +34,11 @@
 
 <header class="brand-header">
   <div class="brand-header__bar">
-    <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+    <a href="index.html" class="brand-header__identity" data-firm-name-aria-label="{firm} home">
       <span class="brand-header__glyph" aria-hidden="true">SE</span>
       <span class="brand-header__lockup">
         <span>Software Advisory</span>
-        <span>Brightscale Partners</span>
+        <span data-firm-name></span>
       </span>
     </a>
     <nav class="brand-header__nav" aria-label="Primary">
@@ -316,7 +316,7 @@
         <div class="flex items-center gap-3">
           <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-amber-400/20 text-lg font-semibold text-amber-200">SE</span>
           <div class="text-sm">
-            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+            <p class="font-semibold tracking-[0.3em] text-slate-400"><span data-firm-name></span></p>
             <p class="text-slate-300">Software Advisory &amp; Transformation</p>
           </div>
         </div>
@@ -345,7 +345,7 @@
       </div>
     </div>
     <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
-      <p>© 2024 Brightscale Partners. All rights reserved.</p>
+      <p>© 2024 <span data-firm-name></span>. All rights reserved.</p>
       <div class="flex flex-wrap gap-6">
         <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
         <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
@@ -546,5 +546,6 @@ document.addEventListener('DOMContentLoaded', () => {
   mobileNav.addEventListener('change', e => { window.location.hash = e.target.value; });
 });
 </script>
+  <script type="module" src="scripts/branding/apply-firm-name.js"></script>
 </body>
 </html>

--- a/Platform_Engineering.html
+++ b/Platform_Engineering.html
@@ -66,11 +66,11 @@
     <!-- Global Brand Header -->
     <header class="brand-header">
         <div class="brand-header__bar">
-            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+            <a href="index.html" class="brand-header__identity" data-firm-name-aria-label="{firm} home">
                 <span class="brand-header__glyph" aria-hidden="true">SE</span>
                 <span class="brand-header__lockup">
                     <span>Software Advisory</span>
-                    <span>Brightscale Partners</span>
+                    <span data-firm-name></span>
                 </span>
             </a>
             <nav class="brand-header__nav" aria-label="Primary">
@@ -517,7 +517,7 @@
                     <div class="flex items-center gap-3">
                         <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-sky-400/20 text-lg font-semibold text-sky-200">SE</span>
                         <div class="text-sm">
-                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="font-semibold tracking-[0.3em] text-slate-400"><span data-firm-name></span></p>
                             <p class="text-slate-300">Software Advisory &amp; Transformation</p>
                         </div>
                     </div>
@@ -546,7 +546,7 @@
                 </div>
             </div>
             <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
-                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <p>© 2024 <span data-firm-name></span>. All rights reserved.</p>
                 <div class="flex flex-wrap gap-6">
                     <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
                     <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
@@ -555,5 +555,6 @@
             </div>
         </div>
     </footer>
+  <script type="module" src="scripts/branding/apply-firm-name.js"></script>
 </body>
 </html>

--- a/Software_Code_Pipeline.html
+++ b/Software_Code_Pipeline.html
@@ -79,11 +79,11 @@
 <body class="antialiased">
     <header class="brand-header">
         <div class="brand-header__bar">
-            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+            <a href="index.html" class="brand-header__identity" data-firm-name-aria-label="{firm} home">
                 <span class="brand-header__glyph" aria-hidden="true">SE</span>
                 <span class="brand-header__lockup">
                     <span>Software Advisory</span>
-                    <span>Brightscale Partners</span>
+                    <span data-firm-name></span>
                 </span>
             </a>
             <nav class="brand-header__nav" aria-label="Primary">
@@ -436,7 +436,7 @@
                     <div class="flex items-center gap-3">
                         <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-sky-400/20 text-lg font-semibold text-sky-200">SE</span>
                         <div class="text-sm">
-                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="font-semibold tracking-[0.3em] text-slate-400"><span data-firm-name></span></p>
                             <p class="text-slate-300">Software Advisory &amp; Transformation</p>
                         </div>
                     </div>
@@ -465,7 +465,7 @@
                 </div>
             </div>
             <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
-                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <p>© 2024 <span data-firm-name></span>. All rights reserved.</p>
                 <div class="flex flex-wrap gap-6">
                     <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
                     <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
@@ -474,5 +474,6 @@
             </div>
         </div>
     </footer>
+  <script type="module" src="scripts/branding/apply-firm-name.js"></script>
 </body>
 </html>

--- a/Software_Security_Detailed.html
+++ b/Software_Security_Detailed.html
@@ -162,11 +162,11 @@
 
     <header class="brand-header">
         <div class="brand-header__bar">
-            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+            <a href="index.html" class="brand-header__identity" data-firm-name-aria-label="{firm} home">
                 <span class="brand-header__glyph" aria-hidden="true">SE</span>
                 <span class="brand-header__lockup">
                     <span>Software Advisory</span>
-                    <span>Brightscale Partners</span>
+                    <span data-firm-name></span>
                 </span>
             </a>
             <nav class="brand-header__nav" aria-label="Primary">
@@ -565,7 +565,7 @@
                     <div class="flex items-center gap-3">
                         <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-blue-400/20 text-lg font-semibold text-blue-200">SE</span>
                         <div class="text-sm">
-                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="font-semibold tracking-[0.3em] text-slate-400"><span data-firm-name></span></p>
                             <p class="text-slate-300">Software Advisory &amp; Transformation</p>
                         </div>
                     </div>
@@ -594,7 +594,7 @@
                 </div>
             </div>
             <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
-                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <p>© 2024 <span data-firm-name></span>. All rights reserved.</p>
                 <div class="flex flex-wrap gap-6">
                     <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
                     <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
@@ -603,5 +603,6 @@
             </div>
         </div>
     </footer>
+  <script type="module" src="scripts/branding/apply-firm-name.js"></script>
 </body>
 </html>

--- a/Software_Security_Summary.html
+++ b/Software_Security_Summary.html
@@ -38,11 +38,11 @@
 <body class="smooth-scroll">
   <header class="brand-header">
     <div class="brand-header__bar">
-      <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+      <a href="index.html" class="brand-header__identity" data-firm-name-aria-label="{firm} home">
         <span class="brand-header__glyph" aria-hidden="true">SE</span>
         <span class="brand-header__lockup">
           <span>Software Advisory</span>
-          <span>Brightscale Partners</span>
+          <span data-firm-name></span>
         </span>
       </a>
       <nav class="brand-header__nav" aria-label="Primary">
@@ -264,7 +264,7 @@
           <div class="flex items-center gap-3">
             <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-blue-400/20 text-lg font-semibold text-blue-200">SE</span>
             <div class="text-sm">
-              <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+              <p class="font-semibold tracking-[0.3em] text-slate-400"><span data-firm-name></span></p>
               <p class="text-slate-300">Software Advisory &amp; Transformation</p>
             </div>
           </div>
@@ -293,7 +293,7 @@
         </div>
       </div>
       <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
-        <p>© 2024 Brightscale Partners. All rights reserved.</p>
+        <p>© 2024 <span data-firm-name></span>. All rights reserved.</p>
         <div class="flex flex-wrap gap-6">
           <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
           <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
@@ -302,5 +302,6 @@
       </div>
     </div>
   </footer>
+  <script type="module" src="scripts/branding/apply-firm-name.js"></script>
 </body>
 </html>

--- a/Software_Supply_Chain.html
+++ b/Software_Supply_Chain.html
@@ -49,11 +49,11 @@
 <body class="smooth-scroll p-4">
     <header class="brand-header">
         <div class="brand-header__bar">
-            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+            <a href="index.html" class="brand-header__identity" data-firm-name-aria-label="{firm} home">
                 <span class="brand-header__glyph" aria-hidden="true">SE</span>
                 <span class="brand-header__lockup">
                     <span>Software Advisory</span>
-                    <span>Brightscale Partners</span>
+                    <span data-firm-name></span>
                 </span>
             </a>
             <nav class="brand-header__nav" aria-label="Primary">
@@ -296,7 +296,7 @@
 
         <section id="advisory" class="mb-8 content-section">
             <h2 class="text-2xl font-bold text-gray-800 border-b-2 border-blue-500 pb-2 mb-4">Brightscale Advisory Playbooks</h2>
-            <p>Brightscale Partners couples security assurance, FinOps governance, and engineering enablement to accelerate software supply chain resilience. Our advisors embed with platform, security, and sourcing leaders to deliver measurable control uplift without derailing release cadences.</p>
+            <p><span data-firm-name></span> couples security assurance, FinOps governance, and engineering enablement to accelerate software supply chain resilience. Our advisors embed with platform, security, and sourcing leaders to deliver measurable control uplift without derailing release cadences.</p>
             <div class="mt-6 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
                 <div class="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
                     <h3 class="text-lg font-semibold text-slate-900">SBOM FastTrack</h3>
@@ -434,7 +434,7 @@
                     <div class="flex items-center gap-3">
                         <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-blue-400/20 text-lg font-semibold text-blue-200">SE</span>
                         <div class="text-sm">
-                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="font-semibold tracking-[0.3em] text-slate-400"><span data-firm-name></span></p>
                             <p class="text-slate-300">Software Advisory &amp; Transformation</p>
                         </div>
                     </div>
@@ -463,7 +463,7 @@
                 </div>
             </div>
             <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
-                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <p>© 2024 <span data-firm-name></span>. All rights reserved.</p>
                 <div class="flex flex-wrap gap-6">
                     <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
                     <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
@@ -472,5 +472,6 @@
             </div>
         </div>
     </footer>
+  <script type="module" src="scripts/branding/apply-firm-name.js"></script>
 </body>
 </html>

--- a/State_of_Modern_Unit_Testing.html
+++ b/State_of_Modern_Unit_Testing.html
@@ -66,11 +66,11 @@
 
     <header class="brand-header">
         <div class="brand-header__bar">
-            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+            <a href="index.html" class="brand-header__identity" data-firm-name-aria-label="{firm} home">
                 <span class="brand-header__glyph" aria-hidden="true">SE</span>
                 <span class="brand-header__lockup">
                     <span>Software Advisory</span>
-                    <span>Brightscale Partners</span>
+                    <span data-firm-name></span>
                 </span>
             </a>
             <nav class="brand-header__nav" aria-label="Primary">
@@ -582,7 +582,7 @@
                     <div class="flex items-center gap-3">
                         <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-emerald-400/20 text-lg font-semibold text-emerald-200">SE</span>
                         <div class="text-sm">
-                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="font-semibold tracking-[0.3em] text-slate-400"><span data-firm-name></span></p>
                             <p class="text-slate-300">Software Advisory &amp; Transformation</p>
                         </div>
                     </div>
@@ -611,7 +611,7 @@
                 </div>
             </div>
             <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
-                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <p>© 2024 <span data-firm-name></span>. All rights reserved.</p>
                 <div class="flex flex-wrap gap-6">
                     <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
                     <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
@@ -620,5 +620,6 @@
             </div>
         </div>
     </footer>
+  <script type="module" src="scripts/branding/apply-firm-name.js"></script>
 </body>
 </html>

--- a/Top_Challenges_in_Software_Engineering.html
+++ b/Top_Challenges_in_Software_Engineering.html
@@ -72,11 +72,11 @@
 
     <header class="brand-header">
         <div class="brand-header__bar">
-            <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+            <a href="index.html" class="brand-header__identity" data-firm-name-aria-label="{firm} home">
                 <span class="brand-header__glyph" aria-hidden="true">SE</span>
                 <span class="brand-header__lockup">
                     <span>Software Advisory</span>
-                    <span>Brightscale Partners</span>
+                    <span data-firm-name></span>
                 </span>
             </a>
             <nav class="brand-header__nav" aria-label="Primary">
@@ -221,7 +221,7 @@
                 </div>
             </div>
             <div class="mt-10 max-w-4xl mx-auto text-center text-gray-700 space-y-4">
-                <p>Brightscale partners with engineering and product leaders to translate these pillars into funded roadmaps, aligning platform, security, and FinOps owners around measurable milestones.</p>
+                <p><span data-firm-name></span> partners with engineering and product leaders to translate these pillars into funded roadmaps, aligning platform, security, and FinOps owners around measurable milestones.</p>
                 <p>Our multidisciplinary advisors co-create playbooks, stand up governance cadences, and coach executives through the sequencing decisions that unlock durable outcomes.</p>
                 <div class="flex justify-center">
                     <a href="index.html#contact" class="inline-flex items-center justify-center rounded-full bg-emerald-600 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-emerald-500">Book a Strategy Call</a>
@@ -867,7 +867,7 @@
                     <div class="flex items-center gap-3">
                         <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-emerald-400/20 text-lg font-semibold text-emerald-200">SE</span>
                         <div class="text-sm">
-                            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+                            <p class="font-semibold tracking-[0.3em] text-slate-400"><span data-firm-name></span></p>
                             <p class="text-slate-300">Software Advisory &amp; Transformation</p>
                         </div>
                     </div>
@@ -896,7 +896,7 @@
                 </div>
             </div>
             <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
-                <p>© 2024 Brightscale Partners. All rights reserved.</p>
+                <p>© 2024 <span data-firm-name></span>. All rights reserved.</p>
                 <div class="flex flex-wrap gap-6">
                     <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
                     <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
@@ -905,5 +905,6 @@
             </div>
         </div>
     </footer>
+  <script type="module" src="scripts/branding/apply-firm-name.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -27,11 +27,11 @@
         <div class="absolute -top-32 -right-24 h-72 w-72 rounded-full bg-cyan-400/40 blur-3xl" aria-hidden="true"></div>
         <div class="absolute -bottom-32 -left-24 h-72 w-72 rounded-full bg-indigo-500/40 blur-3xl" aria-hidden="true"></div>
         <div class="brand-header__bar relative z-10 w-full">
-          <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+          <a href="index.html" class="brand-header__identity" data-firm-name-aria-label="{firm} home">
             <span class="brand-header__glyph" aria-hidden="true">SE</span>
             <span class="brand-header__lockup">
               <span>Software Advisory</span>
-              <span>Brightscale Partners</span>
+              <span data-firm-name></span>
             </span>
           </a>
           <nav class="brand-header__nav" aria-label="Primary">
@@ -84,7 +84,7 @@
         <div class="grid gap-10 lg:grid-cols-2 lg:items-center">
           <div class="space-y-6">
             <span class="inline-flex items-center gap-2 rounded-full bg-sky-100 px-4 py-1 text-sm font-medium text-sky-700">Trusted Advisors for Modern Engineering Leaders</span>
-            <h2 class="text-3xl font-semibold text-slate-900">Brightscale Partners at a Glance</h2>
+            <h2 class="text-3xl font-semibold text-slate-900" data-firm-name-heading="{firm} at a Glance"></h2>
             <p class="text-lg text-slate-600">
               We help software-driven organizations translate strategy into measurable delivery outcomes. Our senior practitioners bring decades of transformation experience across product engineering, platform modernization, and secure operations to every engagement.
             </p>
@@ -254,7 +254,7 @@
             <span class="inline-flex items-center gap-2 rounded-full bg-slate-900/5 px-4 py-1 text-sm font-semibold text-slate-700">Who We Are</span>
             <h2 class="text-3xl font-semibold text-slate-900">A Boutique Advisory Built for Engineering Transformation</h2>
             <p class="text-lg text-slate-600">
-              Brightscale Partners is an independent firm of senior operators, architects, and change leaders who have scaled software organisations across regulated industries and high-growth disruptors alike. We translate ambitious strategies into programmes your teams can execute—and sustain.
+              <span data-firm-name></span> is an independent firm of senior operators, architects, and change leaders who have scaled software organisations across regulated industries and high-growth disruptors alike. We translate ambitious strategies into programmes your teams can execute—and sustain.
             </p>
             <ul class="grid gap-4 sm:grid-cols-2">
               <li class="flex items-start gap-3 rounded-2xl bg-slate-50 p-4 shadow-sm ring-1 ring-slate-100">
@@ -478,7 +478,7 @@
           <div class="flex items-center gap-3">
             <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-cyan-400/20 text-lg font-semibold text-cyan-200">SE</span>
             <div class="text-sm">
-              <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+              <p class="font-semibold tracking-[0.3em] text-slate-400"><span data-firm-name></span></p>
               <p class="text-slate-300">Software Advisory &amp; Transformation</p>
             </div>
           </div>
@@ -507,7 +507,7 @@
         </div>
       </div>
       <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
-        <p>© 2024 Brightscale Partners. All rights reserved.</p>
+        <p>© 2024 <span data-firm-name></span>. All rights reserved.</p>
         <div class="flex flex-wrap gap-6">
           <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
           <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
@@ -517,5 +517,6 @@
     </div>
   </footer>
 
+  <script type="module" src="scripts/branding/apply-firm-name.js"></script>
 </body>
 </html>

--- a/platform-engineering-executive-report.html
+++ b/platform-engineering-executive-report.html
@@ -371,11 +371,11 @@
 <body class="smooth-scroll" data-theme="dark">
   <header class="brand-header brand-header--on-dark">
     <div class="brand-header__bar">
-      <a href="index.html" class="brand-header__identity" aria-label="Brightscale Partners home">
+      <a href="index.html" class="brand-header__identity" data-firm-name-aria-label="{firm} home">
         <span class="brand-header__glyph" aria-hidden="true">SE</span>
         <span class="brand-header__lockup">
           <span>Software Advisory</span>
-          <span>Brightscale Partners</span>
+          <span data-firm-name></span>
         </span>
       </a>
       <nav class="brand-header__nav" aria-label="Primary">
@@ -713,7 +713,7 @@
         <div class="flex items-center gap-3">
           <span class="inline-flex h-11 w-11 items-center justify-center rounded-full bg-sky-400/20 text-lg font-semibold text-sky-200">SE</span>
           <div class="text-sm">
-            <p class="font-semibold tracking-[0.3em] text-slate-400">Brightscale Partners</p>
+            <p class="font-semibold tracking-[0.3em] text-slate-400"><span data-firm-name></span></p>
             <p class="text-slate-300">Software Advisory &amp; Transformation</p>
           </div>
         </div>
@@ -742,7 +742,7 @@
       </div>
     </div>
     <div class="flex flex-col gap-4 border-t border-slate-800 pt-6 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
-      <p>© 2024 Brightscale Partners. All rights reserved.</p>
+      <p>© 2024 <span data-firm-name></span>. All rights reserved.</p>
       <div class="flex flex-wrap gap-6">
         <a href="#" class="transition hover:text-slate-200">Privacy Policy</a>
         <a href="#" class="transition hover:text-slate-200">Terms of Service</a>
@@ -751,5 +751,6 @@
     </div>
   </div>
 </footer>
+  <script type="module" src="scripts/branding/apply-firm-name.js"></script>
 </body>
 </html>

--- a/scripts/branding/apply-firm-name.js
+++ b/scripts/branding/apply-firm-name.js
@@ -1,0 +1,67 @@
+import { FIRM_NAME, FIRM_NAME_POSSESSIVE } from './config.js';
+
+const TOKEN_REPLACEMENTS = [
+  ['{firm}', FIRM_NAME],
+  ['{firmPossessive}', FIRM_NAME_POSSESSIVE],
+];
+
+const DATA_ATTRIBUTE_PREFIX = 'data-firm-name-';
+const RESERVED_DATA_ATTRIBUTES = new Set([
+  'data-firm-name',
+  'data-firm-name-possessive',
+  'data-firm-name-heading',
+]);
+
+function fillTemplate(template) {
+  if (typeof template !== 'string') {
+    return '';
+  }
+
+  return TOKEN_REPLACEMENTS.reduce(
+    (result, [token, value]) => result.split(token).join(value),
+    template,
+  );
+}
+
+function applyTextContent(selector, value) {
+  document.querySelectorAll(selector).forEach((element) => {
+    element.textContent = value;
+  });
+}
+
+function applyHeadingContent() {
+  document.querySelectorAll('[data-firm-name-heading]').forEach((element) => {
+    const template = element.getAttribute('data-firm-name-heading');
+    element.textContent = template ? fillTemplate(template) : FIRM_NAME;
+  });
+}
+
+function applyAttributeTemplates(element) {
+  Array.from(element.attributes).forEach((attribute) => {
+    const { name, value } = attribute;
+    if (!name.startsWith(DATA_ATTRIBUTE_PREFIX) || RESERVED_DATA_ATTRIBUTES.has(name)) {
+      return;
+    }
+
+    const targetName = name.slice(DATA_ATTRIBUTE_PREFIX.length);
+    if (!targetName) {
+      return;
+    }
+
+    element.setAttribute(targetName, fillTemplate(value));
+  });
+}
+
+function applyFirmName() {
+  applyTextContent('[data-firm-name]', FIRM_NAME);
+  applyTextContent('[data-firm-name-possessive]', FIRM_NAME_POSSESSIVE);
+  applyHeadingContent();
+
+  document.querySelectorAll('*').forEach(applyAttributeTemplates);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', applyFirmName);
+} else {
+  applyFirmName();
+}

--- a/scripts/branding/config.js
+++ b/scripts/branding/config.js
@@ -1,0 +1,7 @@
+export const FIRM_NAME = "Brightscale Partners";
+
+const endsWithS = /s$/i;
+export const FIRM_NAME_POSSESSIVE = endsWithS.test(FIRM_NAME)
+  ? `${FIRM_NAME}'`
+  : `${FIRM_NAME}'s`;
+


### PR DESCRIPTION
## Summary
- add a shared branding config and DOM helper to inject the firm name and possessive forms
- update all HTML reports to reference placeholders for the firm name and load the branding script instead of hard-coding text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce3f1581808325921d08d07f109bd7